### PR TITLE
total rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@
 `devslog` is zero dependency custom logging handler for Go's standard [`log/slog`](https://pkg.go.dev/log/slog) package that provides structured logging with colorful and indented structure for developing.
 
 ### Develop with this output
-![image](https://github.com/golang-cz/devslog/assets/17728576/0bae7ec7-0513-41a4-9682-0e0fc74747e7)
+![image](https://github.com/golang-cz/devslog/assets/17728576/cfdc1634-16fe-4dd0-a643-21bf519cd4fe)
 
 ### Instead of these outputs
 `TextHandler`
-![image](https://github.com/golang-cz/devslog/assets/17728576/856f7e34-dc72-4f22-bd47-9fd5cbf7dd2f)
+![image](https://github.com/golang-cz/devslog/assets/17728576/49aab1c0-93ba-409d-8637-a96eeeaaf0e1)
+
 `JSONHandler`
-![image](https://github.com/golang-cz/devslog/assets/17728576/3d4b091d-813a-461d-88e1-4cc95b9d6939)
+![image](https://github.com/golang-cz/devslog/assets/17728576/775af693-2f96-47e8-9190-5ead77b41a27)
 
 ## Install
 ```
@@ -26,7 +27,7 @@ w := os.Stdout
 
 logger := slog.New(devslog.NewHandler(w, nil))
 
-// set global logger
+// optional: set global logger
 slog.SetDefault(logger)
 ```
 

--- a/attributes.go
+++ b/attributes.go
@@ -19,7 +19,7 @@ func (a attributes) Less(i, j int) bool {
 func (a attributes) padding(c foregroundColor) int {
 	var padding int
 	for _, e := range a {
-		color := len(cs(e.Key, c))
+		color := len(cs([]byte(e.Key), c))
 		if color > padding {
 			padding = color
 		}

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -5,7 +5,16 @@ import (
 	"testing"
 )
 
-func Test_AttributesLen(t *testing.T) {
+func Test_Attributes(t *testing.T) {
+	test_AttributesLen(t)
+	test_AttributesSwap(t)
+	test_AttributesLess(t)
+	test_AttributesLessGroupTrue(t)
+	test_AttributesLessGroupFalse(t)
+	test_AttributesPadding(t)
+}
+
+func test_AttributesLen(t *testing.T) {
 	someValue := slog.StringValue("value")
 	attrs := attributes{
 		slog.Attr{Key: "key1", Value: someValue},
@@ -21,7 +30,7 @@ func Test_AttributesLen(t *testing.T) {
 	}
 }
 
-func Test_AttributesSwap(t *testing.T) {
+func test_AttributesSwap(t *testing.T) {
 	attr1 := slog.Attr{Key: "key1", Value: slog.StringValue("value")}
 	attr2 := slog.Attr{Key: "key2", Value: slog.StringValue("value")}
 	attrs := attributes{
@@ -36,7 +45,7 @@ func Test_AttributesSwap(t *testing.T) {
 	}
 }
 
-func Test_AttributesLess(t *testing.T) {
+func test_AttributesLess(t *testing.T) {
 	someValue := slog.StringValue("value")
 	attrs := attributes{
 		slog.Attr{Key: "key1", Value: someValue},
@@ -50,7 +59,7 @@ func Test_AttributesLess(t *testing.T) {
 	}
 }
 
-func Test_AttributesLessGroupTrue(t *testing.T) {
+func test_AttributesLessGroupTrue(t *testing.T) {
 	attrs := attributes{
 		slog.String("key1", "someValue"),
 		slog.Group("key2", slog.String("someString", "someValue")),
@@ -63,7 +72,7 @@ func Test_AttributesLessGroupTrue(t *testing.T) {
 	}
 }
 
-func Test_AttributesLessGroupFalse(t *testing.T) {
+func test_AttributesLessGroupFalse(t *testing.T) {
 	attrs := attributes{
 		slog.Group("key1", slog.String("someString", "someValue")),
 		slog.String("key2", "someValue"),
@@ -76,7 +85,7 @@ func Test_AttributesLessGroupFalse(t *testing.T) {
 	}
 }
 
-func Test_AttributesPadding(t *testing.T) {
+func test_AttributesPadding(t *testing.T) {
 	someValue := slog.StringValue("value")
 	attrs := attributes{
 		slog.Attr{Key: "key1", Value: someValue},

--- a/color.go
+++ b/color.go
@@ -1,56 +1,64 @@
 package devslog
 
-import "fmt"
-
 type (
-	foregroundColor   string
-	backgroundColor   string
-	commonValuesColor string
+	foregroundColor   []byte
+	backgroundColor   []byte
+	commonValuesColor []byte
 )
 
-const (
+var (
 	// Foreground colors
-	fgBlack   foregroundColor = "\x1b[30m"
-	fgRed     foregroundColor = "\x1b[31m"
-	fgGreen   foregroundColor = "\x1b[32m"
-	fgYellow  foregroundColor = "\x1b[33m"
-	fgBlue    foregroundColor = "\x1b[34m"
-	fgMagenta foregroundColor = "\x1b[35m"
-	fgCyan    foregroundColor = "\x1b[36m"
-	fgWhite   foregroundColor = "\x1b[37m"
+	fgBlack   foregroundColor = []byte("\x1b[30m")
+	fgRed     foregroundColor = []byte("\x1b[31m")
+	fgGreen   foregroundColor = []byte("\x1b[32m")
+	fgYellow  foregroundColor = []byte("\x1b[33m")
+	fgBlue    foregroundColor = []byte("\x1b[34m")
+	fgMagenta foregroundColor = []byte("\x1b[35m")
+	fgCyan    foregroundColor = []byte("\x1b[36m")
+	fgWhite   foregroundColor = []byte("\x1b[37m")
 
 	// Background colors
-	bgBlack   backgroundColor = "\x1b[40m"
-	bgRed     backgroundColor = "\x1b[41m"
-	bgGreen   backgroundColor = "\x1b[42m"
-	bgYellow  backgroundColor = "\x1b[43m"
-	bgBlue    backgroundColor = "\x1b[44m"
-	bgMagenta backgroundColor = "\x1b[45m"
-	bgCyan    backgroundColor = "\x1b[46m"
-	bgWhite   backgroundColor = "\x1b[47m"
+	bgBlack   backgroundColor = []byte("\x1b[40m")
+	bgRed     backgroundColor = []byte("\x1b[41m")
+	bgGreen   backgroundColor = []byte("\x1b[42m")
+	bgYellow  backgroundColor = []byte("\x1b[43m")
+	bgBlue    backgroundColor = []byte("\x1b[44m")
+	bgMagenta backgroundColor = []byte("\x1b[45m")
+	bgCyan    backgroundColor = []byte("\x1b[46m")
+	bgWhite   backgroundColor = []byte("\x1b[47m")
 
 	// Common consts
-	resetColor     commonValuesColor = "\x1b[0m"
-	faintColor     commonValuesColor = "\x1b[2m"
-	underlineColor commonValuesColor = "\x1b[4m"
+	resetColor     commonValuesColor = []byte("\x1b[0m")
+	faintColor     commonValuesColor = []byte("\x1b[2m")
+	underlineColor commonValuesColor = []byte("\x1b[4m")
 )
 
 // Color string foreground
-func cs(text string, fgColor foregroundColor) string {
-	return fmt.Sprintf("%v%v%v", fgColor, text, resetColor)
+func cs(b []byte, fgColor foregroundColor) []byte {
+	b = append(fgColor, b...)
+	b = append(b, resetColor...)
+	return b
 }
 
 // Color string fainted
-func csf(text string, fgColor foregroundColor) string {
-	return fmt.Sprintf("%v%v%v%v", fgColor, faintColor, text, resetColor)
+func csf(b []byte, fgColor foregroundColor) []byte {
+	b = append(fgColor, b...)
+	b = append(faintColor, b...)
+	b = append(b, resetColor...)
+	return b
 }
 
 // Color string background
-func csb(text string, fgColor foregroundColor, bgColor backgroundColor) string {
-	return fmt.Sprintf("%v%v%v%v", fgColor, bgColor, text, resetColor)
+func csb(b []byte, fgColor foregroundColor, bgColor backgroundColor) []byte {
+	b = append(fgColor, b...)
+	b = append(bgColor, b...)
+	b = append(b, resetColor...)
+	return b
 }
 
 // Underline text
-func ul(text string) string {
-	return fmt.Sprintf("%v%v%v", underlineColor, text, resetColor)
+func ul(b []byte) []byte {
+	b = append(underlineColor, b...)
+	b = append(b, resetColor...)
+	return b
 }

--- a/color_test.go
+++ b/color_test.go
@@ -1,41 +1,50 @@
 package devslog
 
 import (
+	"bytes"
 	"testing"
 )
 
-func Test_ColorCs(t *testing.T) {
-	expected := "\x1b[32mHello\x1b[0m"
-	result := cs("Hello", fgGreen)
+func Test_Color(t *testing.T) {
+	b := []byte("Hello")
+	test_ColorCs(t, b)
+	test_ColorCsf(t, b)
+	test_ColorCsb(t, b)
+	test_ColorUl(t, b)
+}
 
-	if result != expected {
-		t.Errorf("Expected: %q, but got: %q", expected, result)
+func test_ColorCs(t *testing.T, b []byte) {
+	result := cs(b, fgGreen)
+
+	expected := []byte("\x1b[32mHello\x1b[0m")
+	if !bytes.Equal(expected, result) {
+		t.Errorf("\nExpected: %s\nResult:   %s\nExpected: %[1]q\nResult:   %[2]q", expected, result)
 	}
 }
 
-func Test_ColorCsf(t *testing.T) {
-	expected := "\x1b[34m\x1b[2mHello\x1b[0m"
-	result := csf("Hello", fgBlue)
+func test_ColorCsf(t *testing.T, b []byte) {
+	result := csf(b, fgBlue)
 
-	if result != expected {
-		t.Errorf("Expected: %q, but got: %q", expected, result)
+	expected := []byte("\x1b[2m\x1b[34mHello\x1b[0m")
+	if !bytes.Equal(expected, result) {
+		t.Errorf("\nExpected: %s\nResult:   %s\nExpected: %[1]q\nResult:   %[2]q", expected, result)
 	}
 }
 
-func Test_ColorCsb(t *testing.T) {
-	expected := "\x1b[35m\x1b[43mHello\x1b[0m"
-	result := csb("Hello", fgMagenta, bgYellow)
+func test_ColorCsb(t *testing.T, b []byte) {
+	result := csb(b, fgYellow, bgRed)
 
-	if result != expected {
-		t.Errorf("Expected: %q, but got: %q", expected, result)
+	expected := []byte("\x1b[41m\x1b[33mHello\x1b[0m")
+	if !bytes.Equal(expected, result) {
+		t.Errorf("\nExpected: %s\nResult:   %s\nExpected: %[1]q\nResult:   %[2]q", expected, result)
 	}
 }
 
-func Test_ColorUl(t *testing.T) {
-	expected := "\x1b[4mHello\x1b[0m"
-	result := ul("Hello")
+func test_ColorUl(t *testing.T, b []byte) {
+	result := ul(b)
 
-	if result != expected {
-		t.Errorf("Expected: %q, but got: %q", expected, result)
+	expected := []byte("\x1b[4mHello\x1b[0m")
+	if !bytes.Equal(expected, result) {
+		t.Errorf("\nExpected: %s\nResult:   %s\nExpected: %[1]q\nResult:   %[2]q", expected, result)
 	}
 }

--- a/devslog.go
+++ b/devslog.go
@@ -1,17 +1,19 @@
 package devslog
 
 import (
+	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/url"
+	"reflect"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 type developHandler struct {
@@ -40,17 +42,17 @@ type groupOrAttrs struct {
 	attrs []slog.Attr
 }
 
-func NewHandler(out io.Writer, opts *Options) *developHandler {
+func NewHandler(out io.Writer, o *Options) *developHandler {
 	h := &developHandler{out: out, mu: &sync.Mutex{}}
-	if opts != nil {
-		h.opts = *opts
+	if o != nil {
+		h.opts = *o
 
-		if opts.HandlerOptions != nil {
-			h.opts.HandlerOptions = opts.HandlerOptions
-			if opts.Level == nil {
+		if o.HandlerOptions != nil {
+			h.opts.HandlerOptions = o.HandlerOptions
+			if o.Level == nil {
 				h.opts.Level = slog.LevelInfo
 			} else {
-				h.opts.HandlerOptions.Level = opts.HandlerOptions.Level
+				h.opts.HandlerOptions.Level = o.HandlerOptions.Level
 			}
 		} else {
 			h.opts.HandlerOptions = &slog.HandlerOptions{
@@ -58,11 +60,11 @@ func NewHandler(out io.Writer, opts *Options) *developHandler {
 			}
 		}
 
-		if opts.MaxSlicePrintSize == 0 {
+		if o.MaxSlicePrintSize == 0 {
 			h.opts.MaxSlicePrintSize = 50
 		}
 
-		if opts.TimeFormat == "" {
+		if o.TimeFormat == "" {
 			h.opts.TimeFormat = "[15:06:05]"
 		}
 	} else {
@@ -76,24 +78,24 @@ func NewHandler(out io.Writer, opts *Options) *developHandler {
 	return h
 }
 
-func (h *developHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	return level >= h.opts.Level.Level()
+func (h *developHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return l >= h.opts.Level.Level()
 }
 
-func (h *developHandler) WithGroup(name string) slog.Handler {
-	if name == "" {
+func (h *developHandler) WithGroup(s string) slog.Handler {
+	if s == "" {
 		return h
 	}
 
-	return h.withGroupOrAttrs(groupOrAttrs{group: name})
+	return h.withGroupOrAttrs(groupOrAttrs{group: s})
 }
 
-func (h *developHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	if len(attrs) == 0 {
+func (h *developHandler) WithAttrs(as []slog.Attr) slog.Handler {
+	if len(as) == 0 {
 		return h
 	}
 
-	return h.withGroupOrAttrs(groupOrAttrs{attrs: attrs})
+	return h.withGroupOrAttrs(groupOrAttrs{attrs: as})
 }
 
 func (h *developHandler) withGroupOrAttrs(goa groupOrAttrs) *developHandler {
@@ -105,71 +107,74 @@ func (h *developHandler) withGroupOrAttrs(goa groupOrAttrs) *developHandler {
 }
 
 func (h *developHandler) Handle(ctx context.Context, r slog.Record) error {
-	buf := make([]byte, 0, 1024)
-	buf = fmt.Appendf(buf, "%s ", csf(r.Time.Format(h.opts.TimeFormat), fgWhite))
-	buf = h.formatSourceInfo(buf, &r)
-	buf = h.levelMessage(buf, &r)
-	buf = h.processAttributes(buf, &r)
+	b := make([]byte, 0, 1024)
+	b = append(b, csf([]byte(r.Time.Format(h.opts.TimeFormat)), fgWhite)...)
+	b = append(b, ' ')
+	b = h.formatSourceInfo(b, &r)
+	b = h.levelMessage(b, &r)
+	b = h.processAttributes(b, &r)
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	_, err := h.out.Write(buf)
+	_, err := h.out.Write(b)
 
 	return err
 }
 
-func (h *developHandler) formatSourceInfo(buf []byte, r *slog.Record) []byte {
+func (h *developHandler) formatSourceInfo(b []byte, r *slog.Record) []byte {
 	if h.opts.AddSource {
-		at := cs("@@@", fgBlue)
-		frame, _ := runtime.CallersFrames([]uintptr{r.PC}).Next()
-		source := ul(cs(frame.File, fgYellow))
-		line := cs(strconv.Itoa(frame.Line), fgRed)
-		buf = fmt.Appendf(buf, "%s %s:%s\n", at, source, line)
+		f, _ := runtime.CallersFrames([]uintptr{r.PC}).Next()
+		b = append(b, cs([]byte("@@@"), fgBlue)...)
+		b = append(b, ' ')
+		b = append(b, ul(cs([]byte(f.File), fgYellow))...)
+		b = append(b, ':')
+		b = append(b, cs([]byte(strconv.Itoa(f.Line)), fgRed)...)
+		b = append(b, '\n')
 	}
 
-	return buf
+	return b
 }
 
-func (h *developHandler) levelMessage(buf []byte, r *slog.Record) []byte {
+func (h *developHandler) levelMessage(b []byte, r *slog.Record) []byte {
 	var bgColor backgroundColor
 	var fgColor foregroundColor
-	var lvlStr string
+	var ls string
 	if h.opts.ReplaceAttr != nil {
 		a := h.opts.ReplaceAttr(nil, slog.Any(slog.LevelKey, r.Level))
-		lvlStr = a.Value.String()
+		ls = a.Value.String()
 		if a.Key != "level" {
 			r.AddAttrs(a)
 		}
 	} else {
-		lvlStr = r.Level.String()
+		ls = r.Level.String()
 	}
 
-	level := r.Level
+	lr := r.Level
 	switch {
-	case level < 0:
+	case lr < 0:
 		bgColor, fgColor = bgBlue, fgBlue
-	case level < 4:
+	case lr < 4:
 		bgColor, fgColor = bgGreen, fgGreen
-	case level < 8:
+	case lr < 8:
 		bgColor, fgColor = bgYellow, fgYellow
 	default:
 		bgColor, fgColor = bgRed, fgRed
 	}
 
-	lvl := csb(" "+lvlStr+" ", fgBlack, bgColor)
-	msg := cs(r.Message, fgColor)
+	b = append(b, csb([]byte(" "+ls+" "), fgBlack, bgColor)...)
+	b = append(b, ' ')
+	b = append(b, cs([]byte(r.Message), fgColor)...)
+	b = append(b, '\n')
 
-	buf = fmt.Appendf(buf, "%s %s\n", lvl, msg)
-
-	return buf
+	return b
 }
 
-func (h *developHandler) processAttributes(buf []byte, r *slog.Record) []byte {
-	var attrs attributes
+func (h *developHandler) processAttributes(b []byte, r *slog.Record) []byte {
+	var as attributes
 	if r.NumAttrs() != 0 {
 		r.Attrs(func(a slog.Attr) bool {
-			attrs = append(attrs, a)
+			as = append(as, a)
 			return true
 		})
 	}
@@ -183,175 +188,352 @@ func (h *developHandler) processAttributes(buf []byte, r *slog.Record) []byte {
 
 	for i := len(goas) - 1; i >= 0; i-- {
 		if goas[i].group != "" {
-			newGroup := slog.Attr{
+			ng := slog.Attr{
 				Key:   goas[i].group,
-				Value: slog.GroupValue(attrs...),
+				Value: slog.GroupValue(as...),
 			}
-			attrs = attributes{newGroup}
+			as = attributes{ng}
 		} else {
-			attrs = append(attrs, goas[i].attrs...)
+			as = append(as, goas[i].attrs...)
 		}
 	}
 
-	buf = h.colorize(buf, attrs, 0, []string{})
-	buf = append(buf, '\n')
-	return buf
+	b = h.colorize(b, as, 0, []string{})
+	b = append(b, '\n')
+	return b
 }
 
-func (h *developHandler) colorize(buf []byte, as attributes, level int, groups []string) []byte {
+func (h *developHandler) colorize(b []byte, as attributes, l int, g []string) []byte {
 	if h.opts.SortKeys {
 		sort.Sort(as)
 	}
 
-	keyColor := fgMagenta
-	padding := as.padding(keyColor)
-
+	p := as.padding(fgMagenta)
 	for _, a := range as {
 		if h.opts.ReplaceAttr != nil {
-			a = h.opts.ReplaceAttr(groups, a)
+			a = h.opts.ReplaceAttr(g, a)
 		}
 
-		key := cs(a.Key, keyColor)
-		val := a.Value.String()
-		var mark string
+		k := cs([]byte(a.Key), fgMagenta)
+		v := []byte(a.Value.String())
+		m := []byte(" ")
 		switch a.Value.Kind() {
 		case slog.KindFloat64, slog.KindInt64, slog.KindUint64:
-			mark = cs("#", fgYellow)
-			val = cs(val, fgYellow)
+			m = cs([]byte("#"), fgYellow)
+			v = cs(v, fgYellow)
 		case slog.KindBool:
-			mark = cs("#", fgRed)
-			val = cs(val, fgRed)
+			m = cs([]byte("#"), fgRed)
+			v = cs(v, fgRed)
 		case slog.KindString:
-			if len(val) == 0 {
-				val = csf("empty", fgWhite)
-			} else if isURL(val) {
-				mark = cs("*", fgBlue)
-				val = cs(val, fgBlue)
+			if len(v) == 0 {
+				v = csf([]byte("empty"), fgWhite)
+			} else if h.isURL(v) {
+				m = cs([]byte("*"), fgBlue)
+				v = ul(cs(v, fgBlue))
 			}
 		case slog.KindTime, slog.KindDuration:
-			mark = cs("@", fgCyan)
-			val = cs(val, fgCyan)
+			m = cs([]byte("@"), fgCyan)
+			v = cs(v, fgCyan)
 		case slog.KindAny:
-			a := a.Value.Any()
-			err, isError := a.(error)
-			if isError {
-				mark = cs("E", fgRed)
-				val = csb(fmt.Sprintf(" %v ", err), fgBlack, bgRed)
+			any := a.Value.Any()
+
+			err, isErr := any.(error)
+			if isErr {
+				m = cs([]byte("E"), fgRed)
+				v = h.formatError(err, l)
 				break
 			}
 
-			jsonBytes, err := json.Marshal(a)
-			if err != nil {
+			timeT, isTim := any.(*time.Time)
+			if isTim {
+				m = cs([]byte("@"), fgCyan)
+				v = cs([]byte(timeT.String()), fgCyan)
 				break
 			}
 
-			var decodedData interface{}
-			err = json.Unmarshal(jsonBytes, &decodedData)
-			if err != nil {
+			timeD, isTim := any.(*time.Duration)
+			if isTim {
+				m = cs([]byte("@"), fgCyan)
+				v = cs([]byte(timeD.String()), fgCyan)
 				break
 			}
 
-			switch decoded := decodedData.(type) {
-			case []interface{}:
-				mark = cs("S", fgGreen)
-				val = h.formatSlice(decoded, level)
-			case map[string]interface{}:
-				mark = cs("M", fgGreen)
-				val = h.formatMap(decoded, level)
+			at := reflect.TypeOf(any)
+			av := reflect.ValueOf(any)
+			ut, uv := h.reducePointerTypeValue(at, av)
+
+			switch ut.Kind() {
+			case reflect.Slice:
+				m = cs([]byte("S"), fgGreen)
+				v = h.formatSlice(at, av, l)
+			case reflect.Map:
+				m = cs([]byte("M"), fgGreen)
+				v = h.formatMap(at, av, l)
+			case reflect.Struct:
+				m = cs([]byte("S"), fgYellow)
+				v = h.formatStruct(at, av, 0)
+			case reflect.Float32, reflect.Float64, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				m = cs([]byte("#"), fgYellow)
+				v = cs(atb(uv.Interface()), fgYellow)
+			case reflect.Bool:
+				m = cs([]byte("#"), fgRed)
+				v = cs(atb(uv.Bool()), fgRed)
+			case reflect.String:
+				v = []byte(uv.String())
 			}
 		case slog.KindGroup:
-			mark = cs("G", fgGreen)
-			var groupAttrs attributes
-			groupAttrs = a.Value.Group()
-			groups = append(groups, a.Key)
-			val = fmt.Sprintf("%v\n%s", cs("group", fgGreen), h.colorize(nil, groupAttrs, level+1, groups))
+			m = cs([]byte("G"), fgGreen)
+			var ga attributes
+			ga = a.Value.Group()
+			g = append(g, a.Key)
+
+			v = cs([]byte("============"), fgGreen)
+			v = append(v, '\n')
+			v = append(v, h.colorize(nil, ga, l+1, g)...)
 		}
 
-		buf = fmt.Appendf(buf, "%*v%1v %-*s : %s", level*2, "", mark, padding, key, val)
+		b = append(b, bytes.Repeat([]byte(" "), l*2)...)
+		b = append(b, m...)
+		b = append(b, ' ')
+		b = append(b, k...)
+		b = append(b, bytes.Repeat([]byte(" "), p-len(k))...)
+		b = append(b, ':')
+		b = append(b, ' ')
+		b = append(b, v...)
 		if a.Value.Kind() != slog.KindGroup {
-			buf = append(buf, '\n')
+			b = append(b, '\n')
 		}
 	}
 
-	return buf
+	return b
 }
 
-func isURL(s string) bool {
-	_, err := url.ParseRequestURI(s)
+func (h *developHandler) isURL(u []byte) bool {
+	_, err := url.ParseRequestURI(string(u))
 	return err == nil
 }
 
-func isSlice(s string) bool {
-	return strings.HasPrefix(s, "slice[") && strings.HasSuffix(s, "]")
-}
-
-func isMap(s string) bool {
-	return strings.HasPrefix(s, "map[") && strings.HasSuffix(s, "]")
-}
-
-// Splitting is done by SliceElementDivider
-func (h *developHandler) formatSlice(s []interface{}, l int) string {
-	if len(s) == 0 {
-		return fmt.Sprintf("%v %v", cs("0", fgYellow), cs("slice[]", fgGreen))
-	}
-
-	length := cs(strconv.Itoa(len(s)), fgYellow)
-	digits := len(strconv.Itoa(len(s)))
-	if digits > 3 {
-		digits = 3
-	}
-
-	elementColor := fgBlue
-	res := fmt.Sprintf("%s %s", length, cs("slice[", fgGreen))
-	for i, e := range s {
-		if i == int(h.opts.MaxSlicePrintSize) {
-			res += fmt.Sprintf("\n%*v%*s  %s%s", l*2+4, "", digits, "", cs("...", elementColor), cs("]", fgGreen))
+func (h *developHandler) formatError(err error, l int) (b []byte) {
+	errs := make([][]byte, 0)
+	for err != nil {
+		unwrapErr, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			errs = append(errs, []byte(err.Error()))
 			break
 		}
 
-		res += fmt.Sprintf("\n%*v%*s: %s", l*2+4, "", digits, cs(strconv.Itoa(i), fgGreen), cs(fmt.Sprint(e), elementColor))
-		if i == len(s)-1 {
-			res += fmt.Sprintf(" %s", cs("]", fgGreen))
+		ue := unwrapErr.Unwrap()
+		pe, ok := strings.CutSuffix(err.Error(), ue.Error())
+		if ok {
+			errs = append(errs, []byte(pe))
 		}
+
+		err = ue
 	}
 
-	return res
+	b = append(b, ul(cs([]byte(errs[len(errs)-1]), fgRed))...)
+	d := len(strconv.Itoa(len(errs)))
+	for i, e := range errs {
+		tb := strconv.Itoa(i)
+		b = append(b, '\n')
+		b = append(b, bytes.Repeat([]byte(" "), l*2+4)...)
+		b = append(b, bytes.Repeat([]byte(" "), d-len(tb))...)
+		b = append(b, cs([]byte(tb), fgRed)...)
+		b = append(b, ':')
+		b = append(b, ' ')
+		b = append(b, ul(cs(e, fgRed))...)
+	}
+
+	return b
 }
 
-// Splitting is done by SliceElementDivider,
-func (h *developHandler) formatMap(s map[string]interface{}, level int) string {
-	if len(s) == 0 {
-		return fmt.Sprintf("%v %v", cs("0", fgYellow), cs("map[]", fgGreen))
+func (h *developHandler) formatSlice(st reflect.Type, sv reflect.Value, l int) (b []byte) {
+	ts := h.buildTypeString(st.String())
+	st, sv = h.reducePointerTypeValue(st, sv)
+
+	b = append(b, cs([]byte(strconv.Itoa(sv.Len())), fgBlue)...)
+	b = append(b, ' ')
+	b = append(b, ts...)
+	d := len(strconv.Itoa(sv.Len()))
+	if len(strconv.Itoa(int(h.opts.MaxSlicePrintSize))) < d {
+		d = len(strconv.Itoa(int(h.opts.MaxSlicePrintSize)))
 	}
 
-	var padding int
-	for key := range s {
-		color := len(cs(key, fgGreen))
-		if color > padding {
-			padding = color
+	for i := 0; i < sv.Len(); i++ {
+		if i == int(h.opts.MaxSlicePrintSize) {
+			b = append(b, '\n')
+			b = append(b, bytes.Repeat([]byte(" "), l*2+4)...)
+			b = append(b, bytes.Repeat([]byte(" "), d+2)...)
+			b = append(b, cs([]byte("..."), fgBlue)...)
+			b = append(b, cs([]byte("]"), fgGreen)...)
+			break
 		}
+
+		v := sv.Index(i)
+		t := v.Type()
+
+		tb := strconv.Itoa(i)
+		b = append(b, '\n')
+		b = append(b, bytes.Repeat([]byte(" "), l*2+4)...)
+		b = append(b, bytes.Repeat([]byte(" "), d-len(tb))...)
+		b = append(b, cs([]byte(tb), fgGreen)...)
+		b = append(b, ':')
+		b = append(b, ' ')
+		b = append(b, h.elementType(t, v, l)...)
+
 	}
 
-	sortedKeys := sortDataMap(s)
-	length := cs(strconv.Itoa(len(sortedKeys)), fgYellow)
-	res := fmt.Sprintf("%s %s", length, cs("map[", fgGreen))
-	for i, key := range sortedKeys {
-		res += fmt.Sprintf("\n%*v%-*s : %s", level*2+4, "", padding, cs(key, fgGreen), cs(fmt.Sprint(s[key]), fgBlue))
-		if i == len(sortedKeys)-1 {
-			res += fmt.Sprintf(" %s", cs("]", fgGreen))
-		}
-	}
-
-	return res
+	return b
 }
 
-func sortDataMap(data map[string]interface{}) []string {
-	keys := make([]string, 0, len(data))
-	for key := range data {
-		keys = append(keys, key)
+func (h *developHandler) formatMap(st reflect.Type, sv reflect.Value, l int) (b []byte) {
+	ts := h.buildTypeString(st.String())
+	st, sv = h.reducePointerTypeValue(st, sv)
+
+	p := h.mapKeyPadding(sv, fgGreen)
+	b = append(b, cs([]byte(strconv.Itoa(sv.Len())), fgBlue)...)
+	b = append(b, ' ')
+	b = append(b, ts...)
+	sk := h.sortMapKeys(sv)
+	for _, k := range sk {
+		v := sv.MapIndex(k)
+		v = h.reducePointerValue(v)
+		k = h.reducePointerValue(k)
+
+		tb := cs(atb(k.Interface()), fgGreen)
+		b = append(b, '\n')
+		b = append(b, bytes.Repeat([]byte(" "), l*2+4)...)
+		b = append(b, tb...)
+		b = append(b, bytes.Repeat([]byte(" "), p-len(tb))...)
+		b = append(b, ':')
+		b = append(b, ' ')
+		b = append(b, h.elementType(v.Type(), v, l)...)
 	}
 
-	sort.Strings(keys)
+	return b
+}
 
-	return keys
+func (h *developHandler) formatStruct(st reflect.Type, sv reflect.Value, l int) (b []byte) {
+	b = h.buildTypeString(st.String())
+
+	st, sv = h.reducePointerTypeValue(st, sv)
+	p := h.structKeyPadding(sv, fgGreen)
+
+	for i := 0; i < sv.NumField(); i++ {
+		v := sv.Field(i)
+		t := v.Type()
+
+		tb := cs([]byte(sv.Type().Field(i).Name), fgGreen)
+		b = append(b, '\n')
+		b = append(b, bytes.Repeat([]byte(" "), l*2+4)...)
+		b = append(b, tb...)
+		b = append(b, bytes.Repeat([]byte(" "), p-len(tb))...)
+		b = append(b, ':')
+		b = append(b, ' ')
+		b = append(b, h.elementType(t, v, l)...)
+	}
+
+	return b
+}
+
+func (h *developHandler) elementType(t reflect.Type, v reflect.Value, l int) (b []byte) {
+	switch v.Kind() {
+	case reflect.Slice:
+		b = h.formatSlice(t, v, l+1)
+	case reflect.Map:
+		b = h.formatMap(t, v, l+1)
+	case reflect.Struct:
+		b = h.formatStruct(t, v, l+1)
+	case reflect.Pointer:
+		switch v.Elem().Kind() {
+		case reflect.Slice:
+			b = h.formatSlice(t, v, l+1)
+		case reflect.Map:
+			b = h.formatMap(t, v, l+1)
+		case reflect.Struct:
+			b = h.formatStruct(t, v, l+1)
+		}
+	default:
+		b = atb(v.Interface())
+	}
+
+	return b
+}
+
+func (h *developHandler) buildTypeString(ts string) (b []byte) {
+	t := []byte(ts)
+
+	for len(t) > 0 {
+		switch t[0] {
+		case '*':
+			b = append(b, cs([]byte{t[0]}, fgRed)...)
+		case '[', ']':
+			b = append(b, cs([]byte{t[0]}, fgGreen)...)
+		default:
+			b = append(b, cs([]byte{t[0]}, fgYellow)...)
+		}
+
+		t = t[1:]
+	}
+
+	return b
+}
+
+func (h *developHandler) sortMapKeys(rv reflect.Value) []reflect.Value {
+	ks := make([]reflect.Value, 0, rv.Len())
+	for _, k := range rv.MapKeys() {
+		ks = append(ks, k)
+	}
+
+	sort.Slice(ks, func(i, j int) bool {
+		return fmt.Sprint(ks[i].Interface()) < fmt.Sprint(ks[j].Interface())
+	})
+
+	return ks
+}
+
+func (h *developHandler) mapKeyPadding(rv reflect.Value, fgColor foregroundColor) (p int) {
+	for _, k := range rv.MapKeys() {
+		k = h.reducePointerValue(k)
+		c := len(cs(atb(k.Interface()), fgColor))
+		if c > p {
+			p = c
+		}
+	}
+
+	return p
+}
+
+func (h *developHandler) structKeyPadding(sv reflect.Value, fgColor foregroundColor) (p int) {
+	st := sv.Type()
+	for i := 0; i < sv.NumField(); i++ {
+		c := len(cs([]byte(st.Field(i).Name), fgColor))
+		if c > p {
+			p = c
+		}
+	}
+
+	return p
+}
+
+func (h *developHandler) reducePointerValue(v reflect.Value) reflect.Value {
+	for v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+
+	return v
+}
+
+func (h *developHandler) reducePointerTypeValue(t reflect.Type, v reflect.Value) (reflect.Type, reflect.Value) {
+	for t.Kind() == reflect.Pointer {
+		v = v.Elem()
+		t = v.Type()
+	}
+
+	return t, v
+}
+
+// Any to []byte using fmt.Sprint
+func atb(a any) []byte {
+	return []byte(fmt.Sprint(a))
 }


### PR DESCRIPTION
- using `[]byte` instead of `strings`
- error unwrap
- showing types of slices, maps and structs
- using appending to buffer instead of fmt