### PR TITLE
Optional level colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ slog.SetDefault(logger)
 opts := &devslog.Options{
 	MaxSlicePrintSize: 4,
 	SortKeys:          true,
-	TimeFormat:        "[04:05]"
+	TimeFormat:        "[04:05]",
+	DebugColor:        devslog.Magenta,
 }
 
 logger := slog.New(devslog.NewHandler(os.Stdout, opts))
@@ -91,8 +92,12 @@ slog.SetDefault(logger)
 ```
 
 ## Options
-| Parameter         | Description                                                    | Default      | Value  |
-|-------------------|----------------------------------------------------------------|--------------|--------|
-| MaxSlicePrintSize | Specifies the maximum number of elements to print for a slice. | 50           | uint   |
-| SortKeys          | Determines if attributes should be sorted by keys.             | false        | bool   |
-| TimeFormat        | Time format for timestamp.                                     | "[15:04:05]" | string |
+| Parameter         | Description                                                    | Default        | Value                |
+|-------------------|----------------------------------------------------------------|----------------|----------------------|
+| MaxSlicePrintSize | Specifies the maximum number of elements to print for a slice. | 50             | uint                 |
+| SortKeys          | Determines if attributes should be sorted by keys.             | false          | bool                 |
+| TimeFormat        | Time format for timestamp.                                     | "[15:04:05]"   | string               |
+| DebugColor        | Color for Debug level                                          | devslog.Blue   | devslog.Color (uint) |
+| InfoColor         | Color for Info level                                           | devslog.Green  | devslog.Color (uint) |
+| WarnColor         | Color for Warn level                                           | devslog.Yellow | devslog.Color (uint) |
+| ErrorColor        | Color for Error level                                          | devslog.Red    | devslog.Color (uint) |

--- a/color.go
+++ b/color.go
@@ -6,6 +6,11 @@ type (
 	commonValuesColor []byte
 )
 
+type color struct {
+	fg foregroundColor
+	bg backgroundColor
+}
+
 var (
 	// Foreground colors
 	fgBlack   foregroundColor = []byte("\x1b[30m")
@@ -32,6 +37,40 @@ var (
 	faintColor     commonValuesColor = []byte("\x1b[2m")
 	underlineColor commonValuesColor = []byte("\x1b[4m")
 )
+
+type Color uint
+
+const (
+	UnknownColor Color = iota
+	Black
+	Red
+	Green
+	Yellow
+	Blue
+	Magenta
+	Cyan
+	White
+)
+
+var colors = []color{
+	{},
+	{fgBlack, bgBlack},
+	{fgRed, bgRed},
+	{fgGreen, bgGreen},
+	{fgYellow, bgYellow},
+	{fgBlue, bgBlue},
+	{fgMagenta, bgMagenta},
+	{fgCyan, bgCyan},
+	{fgWhite, bgWhite},
+}
+
+func getColor(c Color) color {
+	if c >= 0 && int(c) < len(colors) {
+		return colors[c]
+	}
+
+	return colors[White]
+}
 
 // Color string foreground
 func cs(b []byte, fgColor foregroundColor) []byte {

--- a/devslog.go
+++ b/devslog.go
@@ -38,9 +38,16 @@ type Options struct {
 	// Time format for timestamp, default format is "[15:04:05]"
 	TimeFormat string
 
+	// Set color for Debug level, default: devslog.Blue
 	DebugColor Color
-	InfoColor  Color
-	WarnColor  Color
+
+	// Set color for Info level, default: devslog.Green
+	InfoColor Color
+
+	// Set color for Warn level, default: devslog.Yellow
+	WarnColor Color
+
+	// Set color for Error level, default: devslog.Red
 	ErrorColor Color
 }
 


### PR DESCRIPTION
Added possibility to define colors for log levels.
As wanted here: https://github.com/golang-cz/devslog/issues/12
```go
opts = devslog.Options{
	DebugColor: devslog.Blue,
	InfoColor:  devslog.Green,
	WarnColor:  devslog.Yellow,
	ErrorColor: devslog.Red,
}
```