### PR TITLE
New line after log

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ opts := &devslog.Options{
 	MaxSlicePrintSize: 4,
 	SortKeys:          true,
 	TimeFormat:        "[04:05]",
+	NewLineAfterLog:   true,
 	DebugColor:        devslog.Magenta,
 }
 
@@ -59,6 +60,7 @@ opts := &devslog.Options{
 	HandlerOptions:    slogOpts,
 	MaxSlicePrintSize: 4,
 	SortKeys:          true,
+	NewLineAfterLog:   true,
 }
 
 logger := slog.New(devslog.NewHandler(os.Stdout, opts))
@@ -82,6 +84,7 @@ if production {
 		HandlerOptions:    slogOpts,
 		MaxSlicePrintSize: 10,
 		SortKeys:          true,
+		NewLineAfterLog:   true,
 	}
 
 	logger = slog.New(devslog.NewHandler(os.Stdout, opts))
@@ -97,6 +100,7 @@ slog.SetDefault(logger)
 | MaxSlicePrintSize | Specifies the maximum number of elements to print for a slice. | 50             | uint                 |
 | SortKeys          | Determines if attributes should be sorted by keys.             | false          | bool                 |
 | TimeFormat        | Time format for timestamp.                                     | "[15:04:05]"   | string               |
+| NewLineAfterLog   | Add blank line after each log                                  | false          | bool                 |
 | DebugColor        | Color for Debug level                                          | devslog.Blue   | devslog.Color (uint) |
 | InfoColor         | Color for Info level                                           | devslog.Green  | devslog.Color (uint) |
 | WarnColor         | Color for Warn level                                           | devslog.Yellow | devslog.Color (uint) |

--- a/devslog.go
+++ b/devslog.go
@@ -38,6 +38,9 @@ type Options struct {
 	// Time format for timestamp, default format is "[15:04:05]"
 	TimeFormat string
 
+	// Add blank line after each log
+	NewLineAfterLog bool
+
 	// Set color for Debug level, default: devslog.Blue
 	DebugColor Color
 
@@ -231,7 +234,10 @@ func (h *developHandler) processAttributes(b []byte, r *slog.Record) []byte {
 	}
 
 	b = h.colorize(b, as, 0, []string{})
-	b = append(b, '\n')
+	if h.opts.NewLineAfterLog {
+		b = append(b, '\n')
+	}
+
 	return b
 }
 

--- a/devslog_test.go
+++ b/devslog_test.go
@@ -56,6 +56,7 @@ func Test_Types(t *testing.T) {
 		MaxSlicePrintSize: 4,
 		SortKeys:          true,
 		TimeFormat:        "[]",
+		NewLineAfterLog:   true,
 	}
 
 	test_String(t, opts)
@@ -296,6 +297,7 @@ func test_Source(t *testing.T) {
 		MaxSlicePrintSize: 4,
 		SortKeys:          true,
 		TimeFormat:        "[15:04]",
+		NewLineAfterLog:   true,
 	}
 
 	logger := slog.New(NewHandler(w, opts))
@@ -324,6 +326,7 @@ func test_WithGroups(t *testing.T) {
 		MaxSlicePrintSize: 4,
 		SortKeys:          true,
 		TimeFormat:        "[]",
+		NewLineAfterLog:   true,
 	}
 
 	logger := slog.New(NewHandler(w, opts).WithGroup("test_group"))
@@ -352,6 +355,7 @@ func test_WithGroupsEmpty(t *testing.T) {
 		MaxSlicePrintSize: 4,
 		SortKeys:          true,
 		TimeFormat:        "[]",
+		NewLineAfterLog:   true,
 	}
 
 	logger := slog.New(NewHandler(w, opts).WithGroup("test_group"))
@@ -378,6 +382,7 @@ func test_WithAttributes(t *testing.T) {
 		MaxSlicePrintSize: 4,
 		SortKeys:          true,
 		TimeFormat:        "[]",
+		NewLineAfterLog:   true,
 	}
 
 	as := []slog.Attr{slog.Any("a", "1")}
@@ -416,6 +421,7 @@ func test_ReplaceLevelAttributes(t *testing.T) {
 		MaxSlicePrintSize: 4,
 		SortKeys:          true,
 		TimeFormat:        "[15:04]",
+		NewLineAfterLog:   true,
 	}
 
 	logger := slog.New(NewHandler(w, opts))


### PR DESCRIPTION
### Description
Added option to add blank line, after each log.
Originally, devslog does this by default.
From now, it has to be declared in options with `NewLineAfterLog: true`.


### true
![image](https://github.com/golang-cz/devslog/assets/17728576/3abcdfa5-5761-4ede-86f7-716a3ece7016)
### false (now default)
![image](https://github.com/golang-cz/devslog/assets/17728576/753da417-66b3-40c9-9011-3af388ee6950)


### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
