### PR TITLE
Maximal nested depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ slog.SetDefault(logger)
 | TimeFormat         | Time format for timestamp.                                     | "[15:04:05]"   | string               |
 | NewLineAfterLog    | Add blank line after each log                                  | false          | bool                 |
 | StringIndentation  | Indent \n in strings                                           | false          | bool                 |
+| MaxNestedDepth     | Maximal nested depth for elements                              | 20             | uint                 |
 | DebugColor         | Color for Debug level                                          | devslog.Blue   | devslog.Color (uint) |
 | InfoColor          | Color for Info level                                           | devslog.Green  | devslog.Color (uint) |
 | WarnColor          | Color for Warn level                                           | devslog.Yellow | devslog.Color (uint) |


### PR DESCRIPTION
### Description
Added maximal nested depth, to prevent infinite loop as reported in this bug #25.
Default value is 20

Tested with:
```go
type Infinite struct {
	ID   int
	This *Infinite
}

func printInfiniteLoop() {
	opts := &devslog.Options{
		MaxNestedDepth: 10,
	}

	logger := slog.New(devslog.NewHandler(os.Stdout, opts))

	v := Infinite{ID: 123}
	v.This = &v
	logger.Info("infinite", slog.Any("test", v))
}
```
![image](https://github.com/golang-cz/devslog/assets/17728576/bebed5a7-fb60-4f3e-bbf8-cdee6198ffc4)

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

