### PR TITLE
ignore unexported fields in struct to avoid panic

### DIFF
--- a/devslog.go
+++ b/devslog.go
@@ -505,6 +505,9 @@ func (h *developHandler) formatStruct(st reflect.Type, sv reflect.Value, l int) 
 	pr := h.structKeyPadding(sv, nil)
 
 	for i := 0; i < sv.NumField(); i++ {
+		if !sv.Type().Field(i).IsExported() {
+			continue
+		}
 		v := sv.Field(i)
 		t := v.Type()
 
@@ -624,6 +627,9 @@ func (h *developHandler) mapKeyPadding(rv reflect.Value, fgColor *foregroundColo
 func (h *developHandler) structKeyPadding(sv reflect.Value, fgColor *foregroundColor) (p int) {
 	st := sv.Type()
 	for i := 0; i < sv.NumField(); i++ {
+		if !st.Field(i).IsExported() {
+			continue
+		}
 		c := len(st.Field(i).Name)
 		if fgColor != nil {
 			c = len(cs([]byte(st.Field(i).Name), *fgColor))

--- a/devslog_test.go
+++ b/devslog_test.go
@@ -679,21 +679,23 @@ func test_Struct(t *testing.T, o *Options) {
 	logger := slog.New(NewHandler(w, o))
 
 	type StructTest struct {
-		Slice   []int
-		Map     map[int]int
-		Struct  struct{ B bool }
-		SliceP  *[]int
-		MapP    *map[int]int
-		StructP *struct{ B bool }
+		Slice      []int
+		Map        map[int]int
+		Struct     struct{ B bool }
+		SliceP     *[]int
+		MapP       *map[int]int
+		StructP    *struct{ B bool }
+		unexported int
 	}
 
 	s := &StructTest{
-		Slice:   []int{},
-		Map:     map[int]int{},
-		Struct:  struct{ B bool }{},
-		SliceP:  &[]int{},
-		MapP:    &map[int]int{},
-		StructP: &struct{ B bool }{},
+		Slice:      []int{},
+		Map:        map[int]int{},
+		Struct:     struct{ B bool }{},
+		SliceP:     &[]int{},
+		MapP:       &map[int]int{},
+		StructP:    &struct{ B bool }{},
+		unexported: 5,
 	}
 
 	logger.Info("msg",


### PR DESCRIPTION
### Description
Please explain the changes you made here.
Fixes bug in #30 

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Code compiles correctly
- [x] Extended the README / documentation, if necessary
