### PR TITLE
Add Stringer support. Fix #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ opts := &devslog.Options{
 	TimeFormat:        "[04:05]",
 	NewLineAfterLog:   true,
 	DebugColor:        devslog.Magenta,
+	StringerFormatter: true,
 }
 
 logger := slog.New(devslog.NewHandler(os.Stdout, opts))
@@ -61,6 +62,7 @@ opts := &devslog.Options{
 	MaxSlicePrintSize: 4,
 	SortKeys:          true,
 	NewLineAfterLog:   true,
+	StringerFormatter: true,
 }
 
 logger := slog.New(devslog.NewHandler(os.Stdout, opts))
@@ -85,6 +87,7 @@ if production {
 		MaxSlicePrintSize: 10,
 		SortKeys:          true,
 		NewLineAfterLog:   true,
+		StringerFormatter: true,
 	}
 
 	logger = slog.New(devslog.NewHandler(os.Stdout, opts))
@@ -107,3 +110,4 @@ slog.SetDefault(logger)
 | WarnColor          | Color for Warn level                                           | devslog.Yellow | devslog.Color (uint) |
 | ErrorColor         | Color for Error level                                          | devslog.Red    | devslog.Color (uint) |
 | MaxErrorStackTrace | Max stack trace frames for errors                              | 0              | uint                 |
+| StringerFormatter  | Use Stringer interface for formatting                          | false          | bool                 |

--- a/devslog.go
+++ b/devslog.go
@@ -58,6 +58,9 @@ type Options struct {
 
 	// Max stack trace frames when unwrapping errors
 	MaxErrorStackTrace uint
+
+	// Use method String() for formatting value
+	StringerFormatter bool
 }
 
 type groupOrAttrs struct {
@@ -311,6 +314,13 @@ func (h *developHandler) colorize(b []byte, as attributes, l int, g []string) []
 				break
 			}
 
+			if h.opts.StringerFormatter {
+				if stringer, ok := av.(fmt.Stringer); ok {
+					v = []byte(stringer.String())
+					break
+				}
+			}
+
 			avt := reflect.TypeOf(av)
 			avv := reflect.ValueOf(av)
 			if avt == nil {
@@ -545,6 +555,12 @@ var marshalTextInterface = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
 func (h *developHandler) elementType(t reflect.Type, v reflect.Value, l int, p int) (b []byte) {
 	if t.Implements(marshalTextInterface) {
 		return atb(v)
+	}
+
+	if h.opts.StringerFormatter {
+		if stringer, ok := v.Interface().(fmt.Stringer); ok {
+			return []byte(stringer.String())
+		}
 	}
 
 	switch v.Kind() {


### PR DESCRIPTION
### Description

Unfortunately, PR [#32 ](https://github.com/golang-cz/devslog/pull/32) does not work as expected. For types that have a `String()` method, output is raw instead of using the method.

Example:
<img width="240" src="https://github.com/golang-cz/devslog/assets/12181586/c9344f1e-82bc-4cdf-bb3c-a9a2c1021c4a">

In this PR, formatting uses the `String()` method if it exists (for any type). 

<img width="277"  src="https://github.com/golang-cz/devslog/assets/12181586/d35abb90-28f8-48ad-89f2-ccc70f5b221c">

Also, for each field in the structure, the existence of this method is also checked, that is, if the parent structure does not have a `String()` method, but the fields do, then we will see normally formatted fields.

<img width="230" src="https://github.com/golang-cz/devslog/assets/12181586/4bda4bd7-3c85-4222-97db-65e712f2ffdb">

Since this behavior may not always be desirable, formatting is only enabled if the `StringerFormatter` option is true.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
