### PR TITLE
No color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # 🧻 devslog - Go [slog.Handler](https://pkg.go.dev/log/slog#Handler) for development
- [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/golang-cz/devslog/blob/master/LICENSE)
- [![Go Report Card](https://goreportcard.com/badge/github.com/golang-cz/devslog)](https://goreportcard.com/report/github.com/golang-cz/devslog)
- [![Go Reference](https://pkg.go.dev/badge/github.com/golang-cz/devslog.svg)](https://pkg.go.dev/github.com/golang-cz/devslog)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/golang-cz/devslog/blob/master/LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/golang-cz/devslog)](https://goreportcard.com/report/github.com/golang-cz/devslog)
+[![Go Reference](https://pkg.go.dev/badge/github.com/golang-cz/devslog.svg)](https://pkg.go.dev/github.com/golang-cz/devslog)
 
 `devslog` is a zero dependency structured logging handler for Go's [`log/slog`](https://pkg.go.dev/log/slog) package with pretty and colorful output for developers.
 
 ### Devslog output
+
 ![image](https://github.com/golang-cz/devslog/assets/17728576/cfdc1634-16fe-4dd0-a643-21bf519cd4fe)
 
 #### Compared to
+
 `TextHandler`
 ![image](https://github.com/golang-cz/devslog/assets/17728576/49aab1c0-93ba-409d-8637-a96eeeaaf0e1)
 
@@ -16,12 +19,15 @@
 ![image](https://github.com/golang-cz/devslog/assets/17728576/775af693-2f96-47e8-9190-5ead77b41a27)
 
 ## Install
+
 ```
 go get github.com/golang-cz/devslog@latest
 ```
 
 ## Examples
+
 ### Logger without options
+
 ```go
 logger := slog.New(devslog.NewHandler(os.Stdout, nil))
 
@@ -30,6 +36,7 @@ slog.SetDefault(logger)
 ```
 
 ### Logger with custom options
+
 ```go
 // new logger with options
 opts := &devslog.Options{
@@ -48,7 +55,9 @@ slog.SetDefault(logger)
 ```
 
 ### Logger with default slog options
+
 Handler accepts default [slog.HandlerOptions](https://pkg.go.dev/golang.org/x/exp/slog#HandlerOptions)
+
 ```go
 // slog.HandlerOptions
 slogOpts := &slog.HandlerOptions{
@@ -72,6 +81,7 @@ slog.SetDefault(logger)
 ```
 
 ### Example usage
+
 ```go
 slogOpts := &slog.HandlerOptions{
 	AddSource: true,
@@ -98,8 +108,9 @@ slog.SetDefault(logger)
 ```
 
 ## Options
+
 | Parameter          | Description                                                    | Default        | Value                |
-|--------------------|----------------------------------------------------------------|----------------|----------------------|
+| ------------------ | -------------------------------------------------------------- | -------------- | -------------------- |
 | MaxSlicePrintSize  | Specifies the maximum number of elements to print for a slice. | 50             | uint                 |
 | SortKeys           | Determines if attributes should be sorted by keys.             | false          | bool                 |
 | TimeFormat         | Time format for timestamp.                                     | "[15:04:05]"   | string               |
@@ -111,3 +122,4 @@ slog.SetDefault(logger)
 | ErrorColor         | Color for Error level                                          | devslog.Red    | devslog.Color (uint) |
 | MaxErrorStackTrace | Max stack trace frames for errors                              | 0              | uint                 |
 | StringerFormatter  | Use Stringer interface for formatting                          | false          | bool                 |
+| NoColor            | Disable coloring                                               | false          | bool                 |

--- a/attributes.go
+++ b/attributes.go
@@ -18,12 +18,12 @@ func (a attributes) Less(i, j int) bool {
 	return a[i].Key < a[j].Key
 }
 
-func (a attributes) padding(c foregroundColor) int {
+func (a attributes) padding(c foregroundColor, colorFunction func(b []byte, fgColor foregroundColor) []byte) int {
 	var padding int
 	for _, e := range a {
 		color := len(e.Key)
 		if c != nil {
-			color = len(cs([]byte(e.Key), c))
+			color = len(colorFunction([]byte(e.Key), c))
 		}
 
 		if color > padding {

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -92,7 +92,8 @@ func test_AttributesPadding(t *testing.T) {
 		slog.Attr{Key: "key2", Value: someValue},
 	}
 
-	padding := attrs.padding(fgMagenta)
+	h := NewHandler(nil, nil)
+	padding := attrs.padding(fgMagenta, h.cs)
 
 	expectedPadding := 13
 	if padding != expectedPadding {

--- a/color.go
+++ b/color.go
@@ -64,7 +64,7 @@ var colors = []color{
 	{fgWhite, bgWhite},
 }
 
-func getColor(c Color) color {
+func (h *developHandler) getColor(c Color) color {
 	if int(c) < len(colors) {
 		return colors[c]
 	}
@@ -73,14 +73,22 @@ func getColor(c Color) color {
 }
 
 // Color string foreground
-func cs(b []byte, fgColor foregroundColor) []byte {
+func (h *developHandler) cs(b []byte, fgColor foregroundColor) []byte {
+	if h.opts.NoColor {
+		return b
+	}
+
 	b = append(fgColor, b...)
 	b = append(b, resetColor...)
 	return b
 }
 
 // Color string fainted
-func csf(b []byte, fgColor foregroundColor) []byte {
+func (h *developHandler) csf(b []byte, fgColor foregroundColor) []byte {
+	if h.opts.NoColor {
+		return b
+	}
+
 	b = append(fgColor, b...)
 	b = append(faintColor, b...)
 	b = append(b, resetColor...)
@@ -88,7 +96,11 @@ func csf(b []byte, fgColor foregroundColor) []byte {
 }
 
 // Color string background
-func csb(b []byte, fgColor foregroundColor, bgColor backgroundColor) []byte {
+func (h *developHandler) csb(b []byte, fgColor foregroundColor, bgColor backgroundColor) []byte {
+	if h.opts.NoColor {
+		return b
+	}
+
 	b = append(fgColor, b...)
 	b = append(bgColor, b...)
 	b = append(b, resetColor...)
@@ -96,7 +108,11 @@ func csb(b []byte, fgColor foregroundColor, bgColor backgroundColor) []byte {
 }
 
 // Underline text
-func ul(b []byte) []byte {
+func (h *developHandler) ul(b []byte) []byte {
+	if h.opts.NoColor {
+		return b
+	}
+
 	b = append(underlineColor, b...)
 	b = append(b, resetColor...)
 	return b

--- a/color_test.go
+++ b/color_test.go
@@ -6,24 +6,25 @@ import (
 )
 
 func Test_Color(t *testing.T) {
-	test_GetColor(t)
+	h := NewHandler(nil, nil)
+	test_GetColor(t, h)
 
 	b := []byte("Hello")
-	test_ColorCs(t, b)
-	test_ColorCsf(t, b)
-	test_ColorCsb(t, b)
-	test_ColorUl(t, b)
+	test_ColorCs(t, b, h)
+	test_ColorCsf(t, b, h)
+	test_ColorCsb(t, b, h)
+	test_ColorUl(t, b, h)
 }
 
-func test_GetColor(t *testing.T) {
-	result := getColor(Black)
+func test_GetColor(t *testing.T, h *developHandler) {
+	result := h.getColor(Black)
 	expected := colors[1].fg
 
 	if !bytes.Equal(expected, result.fg) {
 		t.Errorf("\nExpected: %s\nResult:   %s\nExpected: %[1]q\nResult:   %[2]q", expected, result)
 	}
 
-	result = getColor(Color(20))
+	result = h.getColor(Color(20))
 	expected = colors[8].fg
 
 	if !bytes.Equal(expected, result.fg) {
@@ -31,8 +32,8 @@ func test_GetColor(t *testing.T) {
 	}
 }
 
-func test_ColorCs(t *testing.T, b []byte) {
-	result := cs(b, fgGreen)
+func test_ColorCs(t *testing.T, b []byte, h *developHandler) {
+	result := h.cs(b, fgGreen)
 
 	expected := []byte("\x1b[32mHello\x1b[0m")
 	if !bytes.Equal(expected, result) {
@@ -40,8 +41,8 @@ func test_ColorCs(t *testing.T, b []byte) {
 	}
 }
 
-func test_ColorCsf(t *testing.T, b []byte) {
-	result := csf(b, fgBlue)
+func test_ColorCsf(t *testing.T, b []byte, h *developHandler) {
+	result := h.csf(b, fgBlue)
 
 	expected := []byte("\x1b[2m\x1b[34mHello\x1b[0m")
 	if !bytes.Equal(expected, result) {
@@ -49,8 +50,8 @@ func test_ColorCsf(t *testing.T, b []byte) {
 	}
 }
 
-func test_ColorCsb(t *testing.T, b []byte) {
-	result := csb(b, fgYellow, bgRed)
+func test_ColorCsb(t *testing.T, b []byte, h *developHandler) {
+	result := h.csb(b, fgYellow, bgRed)
 
 	expected := []byte("\x1b[41m\x1b[33mHello\x1b[0m")
 	if !bytes.Equal(expected, result) {
@@ -58,8 +59,8 @@ func test_ColorCsb(t *testing.T, b []byte) {
 	}
 }
 
-func test_ColorUl(t *testing.T, b []byte) {
-	result := ul(b)
+func test_ColorUl(t *testing.T, b []byte, h *developHandler) {
+	result := h.ul(b)
 
 	expected := []byte("\x1b[4mHello\x1b[0m")
 	if !bytes.Equal(expected, result) {

--- a/devslog_test.go
+++ b/devslog_test.go
@@ -76,6 +76,7 @@ func Test_Types(t *testing.T) {
 	test_LogValuerPanic(t, opts)
 	test_Stringer(t, opts)
 	test_StringerInner(t, opts)
+	testNoColor(t, opts)
 }
 
 func test_NewHandlerDefaults(t *testing.T) {
@@ -302,9 +303,10 @@ func test_Source(t *testing.T) {
 		NewLineAfterLog:   true,
 	}
 
-	logger := slog.New(NewHandler(w, opts))
+	h := NewHandler(w, opts)
+	logger := slog.New(h)
 
-	timeString := csf([]byte(time.Now().Format("[15:04]")), fgWhite)
+	timeString := h.csf([]byte(time.Now().Format("[15:04]")), fgWhite)
 	_, filename, l, _ := runtime.Caller(0)
 	logger.Info("message")
 
@@ -426,9 +428,10 @@ func test_ReplaceLevelAttributes(t *testing.T) {
 		NewLineAfterLog:   true,
 	}
 
-	logger := slog.New(NewHandler(w, opts))
+	h := NewHandler(w, opts)
+	logger := slog.New(h)
 
-	timeString := csf([]byte(time.Now().Format("[15:04]")), fgWhite)
+	timeString := h.csf([]byte(time.Now().Format("[15:04]")), fgWhite)
 	ctx := context.Background()
 	logger.Log(ctx, LevelEmergency, "missing pilots")
 	logger.Error("failed to start engines", "err", "missing fuel")
@@ -854,6 +857,25 @@ func test_StringerInner(t *testing.T, o *Options) {
 	expected := []byte(
 		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mtest_stringer_inner\x1b[0m\n\x1b[33mS\x1b[0m \x1b[35mitem1\x1b[0m: \x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33mS\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mE\x1b[0m\x1b[33mx\x1b[0m\x1b[33ma\x1b[0m\x1b[33mm\x1b[0m\x1b[33mp\x1b[0m\x1b[33ml\x1b[0m\x1b[33me\x1b[0m\x1b[33m2\x1b[0m\n    \x1b[32mInner\x1b[0m: A: test\n    \x1b[32mOther\x1b[0m: \x1b[33m42\x1b[0m\n\n",
 	)
+
+	if !bytes.Equal(w.WrittenData, expected) {
+		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)
+	}
+}
+
+func testNoColor(t *testing.T, o *Options) {
+	w := &MockWriter{}
+	o.NoColor = true
+	logger := slog.New(NewHandler(w, o))
+
+	logger.Info("msg",
+		slog.Any("i", 1),
+		slog.Any("f", 2.2),
+		slog.Any("s", "someString"),
+		slog.Any("m", map[int]string{3: "three", 4: "four"}),
+	)
+
+	expected := []byte("[]  INFO  msg\n# f: 2.2\n# i: 1\nM m: 2 map[int]string\n    3: three\n    4: four\n  s: someString\n\n")
 
 	if !bytes.Equal(w.WrittenData, expected) {
 		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)


### PR DESCRIPTION
### Description
Added simple `NoColor` for disabling coloring as requested in #38

This code:
```go
func printNoColor() {
	opts := &devslog.Options{
		NoColor: true,
	}

	l := slog.New(devslog.NewHandler(os.Stdout, opts))
	l.Info("msg",
		slog.Any("integer", 1),
		slog.Any("float", 2.2),
		slog.Any("string", "someString"),
		slog.Any("map", map[int]string{3: "three", 4: "four"}),
	)
}
```
Produce this:
![image](https://github.com/user-attachments/assets/204fa8c2-b8fb-41eb-b101-d82181e997ae)



### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
