### PR TITLE
same source info color

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,17 +109,18 @@ slog.SetDefault(logger)
 
 ## Options
 
-| Parameter          | Description                                                    | Default        | Value                |
-| ------------------ | -------------------------------------------------------------- | -------------- | -------------------- |
-| MaxSlicePrintSize  | Specifies the maximum number of elements to print for a slice. | 50             | uint                 |
-| SortKeys           | Determines if attributes should be sorted by keys.             | false          | bool                 |
-| TimeFormat         | Time format for timestamp.                                     | "[15:04:05]"   | string               |
-| NewLineAfterLog    | Add blank line after each log                                  | false          | bool                 |
-| StringIndentation  | Indent \n in strings                                           | false          | bool                 |
-| DebugColor         | Color for Debug level                                          | devslog.Blue   | devslog.Color (uint) |
-| InfoColor          | Color for Info level                                           | devslog.Green  | devslog.Color (uint) |
-| WarnColor          | Color for Warn level                                           | devslog.Yellow | devslog.Color (uint) |
-| ErrorColor         | Color for Error level                                          | devslog.Red    | devslog.Color (uint) |
-| MaxErrorStackTrace | Max stack trace frames for errors                              | 0              | uint                 |
-| StringerFormatter  | Use Stringer interface for formatting                          | false          | bool                 |
-| NoColor            | Disable coloring                                               | false          | bool                 |
+| Parameter           | Description                                                    | Default        | Value                |
+| ------------------- | -------------------------------------------------------------- | -------------- | -------------------- |
+| MaxSlicePrintSize   | Specifies the maximum number of elements to print for a slice. | 50             | uint                 |
+| SortKeys            | Determines if attributes should be sorted by keys.             | false          | bool                 |
+| TimeFormat          | Time format for timestamp.                                     | "[15:04:05]"   | string               |
+| NewLineAfterLog     | Add blank line after each log                                  | false          | bool                 |
+| StringIndentation   | Indent \n in strings                                           | false          | bool                 |
+| DebugColor          | Color for Debug level                                          | devslog.Blue   | devslog.Color (uint) |
+| InfoColor           | Color for Info level                                           | devslog.Green  | devslog.Color (uint) |
+| WarnColor           | Color for Warn level                                           | devslog.Yellow | devslog.Color (uint) |
+| ErrorColor          | Color for Error level                                          | devslog.Red    | devslog.Color (uint) |
+| MaxErrorStackTrace  | Max stack trace frames for errors                              | 0              | uint                 |
+| StringerFormatter   | Use Stringer interface for formatting                          | false          | bool                 |
+| NoColor             | Disable coloring                                               | false          | bool                 |
+| SameSourceInfoColor | Keep same color for whole source info                          | false          | bool                 |

--- a/devslog.go
+++ b/devslog.go
@@ -64,6 +64,9 @@ type Options struct {
 
 	// Disable coloring
 	NoColor bool
+
+	// Keep same color for whole source info, helpful when you want to open the line of code from terminal, but the ANSI coloring codes are in link itself
+	SameSourceInfoColor bool
 }
 
 type groupOrAttrs struct {
@@ -180,9 +183,15 @@ func (h *developHandler) formatSourceInfo(b []byte, r *slog.Record) []byte {
 		f, _ := runtime.CallersFrames([]uintptr{r.PC}).Next()
 		b = append(b, h.cs([]byte("@@@"), fgBlue)...)
 		b = append(b, ' ')
-		b = append(b, h.ul(h.cs([]byte(f.File), fgYellow))...)
-		b = append(b, ':')
-		b = append(b, h.cs([]byte(strconv.Itoa(f.Line)), fgRed)...)
+
+		if h.opts.SameSourceInfoColor {
+			b = append(b, h.ul(h.cs(append(append([]byte(f.File), ':'), []byte(strconv.Itoa(f.Line))...), fgYellow))...)
+		} else {
+			b = append(b, h.ul(h.cs([]byte(f.File), fgYellow))...)
+			b = append(b, ':')
+			b = append(b, h.cs([]byte(strconv.Itoa(f.Line)), fgRed)...)
+		}
+
 		b = append(b, '\n')
 	}
 


### PR DESCRIPTION
### Description
https://github.com/golang-cz/devslog/issues/47
This adds possibility to print source of the log in same color, so the link doesn't contains ANSI codes in middle of link.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
