### PR TITLE
Colors, examples, fix #49

### DIFF
--- a/_example/Makefile
+++ b/_example/Makefile
@@ -1,0 +1,7 @@
+.PHONY: fmt check-fmt lint vet test
+
+run:
+	rerun -watch . .. -run sh -c 'go run .'
+
+update: 
+	go get github.com/golang-cz/devslog@latest

--- a/_example/go.mod
+++ b/_example/go.mod
@@ -1,0 +1,7 @@
+module testslog
+
+go 1.21.0
+
+replace github.com/golang-cz/devslog => ../
+
+require github.com/golang-cz/devslog v0.0.9-0.20231205161544-41c70164951c

--- a/_example/main.go
+++ b/_example/main.go
@@ -1,0 +1,400 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"time"
+
+	"github.com/golang-cz/devslog"
+)
+
+func main() {
+	production := false
+	json := false
+
+	w := os.Stdout
+
+	slogOpts := &slog.HandlerOptions{
+		AddSource:   true,
+		Level:       slog.LevelDebug,
+		ReplaceAttr: replaceAttr,
+	}
+
+	var logger *slog.Logger
+	if production {
+		if json {
+			logger = slog.New(slog.NewJSONHandler(w, slogOpts))
+		} else {
+			logger = slog.New(slog.NewTextHandler(w, slogOpts))
+		}
+	} else {
+		opts := &devslog.Options{
+			HandlerOptions:    slogOpts,
+			MaxSlicePrintSize: 5,
+			SortKeys:          true,
+			DebugColor:        devslog.Magenta,
+			StringIndentation: true,
+		}
+
+		logger = slog.New(devslog.NewHandler(w, opts))
+	}
+
+	slog.SetDefault(logger)
+
+	log1(false)
+	levels(true)
+	longStrings(false)
+	logSmall(false)
+	printInfiniteLoop(false)
+	printNoColor(false)
+}
+
+const (
+	LevelTrace     = slog.Level(-8)
+	LevelDebug     = slog.LevelDebug
+	LevelInfo      = slog.LevelInfo
+	LevelNotice    = slog.Level(2)
+	LevelWarning   = slog.LevelWarn
+	LevelError     = slog.LevelError
+	LevelEmergency = slog.Level(12)
+)
+
+func replaceAttr(groups []string, a slog.Attr) slog.Attr {
+	switch a.Key {
+	case slog.LevelKey:
+		// Rename the level key from "level" to "sev".
+		// a.Key = "sev"
+
+		// Handle custom level values.
+		level := a.Value.Any().(slog.Level)
+
+		// This could also look up the name from a map or other structure, but
+		// this demonstrates using a switch statement to rename levels. For
+		// maximum performance, the string values should be constants, but this
+		// example uses the raw strings for readability.
+		switch {
+		case level < LevelDebug:
+			a.Value = slog.StringValue("TRACE")
+		case level < LevelInfo:
+			a.Value = slog.StringValue("DEBUG")
+		case level < LevelNotice:
+			a.Value = slog.StringValue("INFO")
+		case level < LevelWarning:
+			a.Value = slog.StringValue("NOTICE")
+		case level < LevelError:
+			a.Value = slog.StringValue("WARNING")
+		case level < LevelEmergency:
+			a.Value = slog.StringValue("ERROR")
+		default:
+			a.Value = slog.StringValue("EMERGENCY")
+		}
+	}
+
+	return a
+}
+
+func levels(log bool) {
+	if !log {
+		return
+	}
+
+	ctx := context.Background()
+	slog.Log(ctx, LevelTrace, "sunrise")
+	slog.Debug("adding fuel")
+	slog.Info("initiating launch")
+	slog.Log(ctx, LevelNotice, "button clicked")
+	slog.Warn("overheating")
+	slog.Error("it is broken")
+	slog.Log(ctx, LevelEmergency, "very much broken")
+}
+
+func log1(log bool) {
+	if !log {
+		return
+	}
+
+	structSlice := []*A{
+		{Num: 2, Str: "2x str"},
+		{Num: 4, Str: "4x str"},
+	}
+
+	mapString := map[string]string{
+		"ba na na": "man go",
+		"apple":    "pear",
+	}
+
+	sliceMap := []map[string]string{
+		mapString,
+		mapString,
+	}
+
+	str1 := "Hello"
+	str2 := "World"
+	str3 := "Goodbye"
+	str4 := "Curled"
+
+	str2p := &str2
+	str4p := &str4
+
+	mapStringPtrs := map[*string]**string{
+		&str1: &str2p,
+		&str3: &str4p,
+	}
+
+	type customString string
+	sliceCustom := []customString{"orange", "ba na na"}
+
+	sliceSmall := []string{"dsa", "ba na na"}
+	var sliceBig []float64
+	for i := 0; i < 10; i++ {
+		sliceBig = append(sliceBig, math.Pow(2, float64(i)))
+	}
+
+	intMap := map[int]int{1: 2, 3: 4, 5: 6}
+	intMapPtr := &intMap
+
+	sliceSlice := []*[]float64{
+		&sliceBig,
+		&sliceBig,
+	}
+
+	person := Person{
+		FirstName: "John",
+		Age:       30,
+		Contact: Contact{
+			Email: "john@example.com",
+			Address: &Address{
+				Street: "123 Main St",
+				Slice:  &sliceBig,
+				Map:    mapStringPtrs,
+			},
+		},
+	}
+
+	mapStruct := make(map[int]*Person, 2)
+	mapStruct[21] = &person
+
+	type slicer []int
+	mapSlice := make(map[int][]float64, 2)
+	mapSlice[0] = sliceBig
+
+	err := fmt.Errorf("so much broken")
+	err = fmt.Errorf("load config: %w", err)
+	err = fmt.Errorf("init app: %w", err)
+
+	a := A{Str: "dsadsa", Num: 45}
+	b := &a
+	c := &b
+	d := &c
+
+	var in uint8 = 21
+	fl := 1.21
+	flp := &fl
+	bool := true
+
+	date := time.Date(2012, time.March, 28, 0, 0, 0, 0, time.UTC)
+	duration := time.Since(date)
+
+	slog.Info(
+		"My INFO message",
+		slog.String("string", "some string"),
+		slog.String("url", "https://go.dev/"),
+		slog.Any("bool", true),
+		slog.Any("time", date),
+		slog.Any("time2", &date),
+		slog.Any("duration", duration),
+		slog.Any("map", mapString),
+		slog.Any("intMap", intMap),
+		slog.Any("sliceSmall", sliceSmall),
+		slog.Any("sliceBig", &sliceBig),
+		slog.Any("sliceSlice", &sliceSlice),
+		slog.Any("sliceCustom", sliceCustom),
+		slog.Any("emptySlice", make([]*int, 0)),
+		slog.Any("mapStringPtrs", mapStringPtrs),
+		slog.Any("sliceMap", sliceMap),
+		slog.Group("innerGroup",
+			slog.Any("flp", &flp),
+			slog.Any("mapStruct", &mapStruct),
+			slog.Any("mapSlice", mapSlice),
+			slog.Any("intPtr", &in),
+			slog.Any("boolPtr", &bool),
+		),
+		slog.Any("err", err),
+		slog.Any("errPtr", &err),
+		slog.Any("person", &person),
+		slog.Any("structs1", &structSlice),
+		slog.Any("optrmap", intMapPtr),
+		slog.Any("structSlice", structSlice),
+		slog.Any("aPtr", &a),
+		slog.Any("a", a),
+		slog.Any("b", B{}),
+		slog.Any("pointersToStruct", d),
+	)
+}
+
+func longStrings(log bool) {
+	if !log {
+		return
+	}
+
+	type LongStrings struct {
+		S1 string
+		S2 string
+	}
+
+	slog.Info("string_group",
+		slog.String("string1", "this is a long string\non multiple lines.\nit would read better if we kept indentation"),
+		slog.String("string11", "this is a long string\non multiple lines.\nit would read better if we kept indentation"),
+		slog.Group("group",
+			slog.String("string1", "this is a long string\non multiple lines.\nit would read better if we kept indentation"),
+			slog.String("string11", "this is a long string\non multiple lines.\nit would read better if we kept indentation"),
+			slog.Any("longStrings", LongStrings{
+				S1: "this is a long string\non multiple lines.\nit would read better if we kept indentation",
+				S2: "this is a long string\non multiple lines.\nit would read better if we kept indentation",
+			}),
+			slog.Group("group",
+				slog.Any("longStrings", LongStrings{
+					S1: "this is a long string\non multiple lines.\nit would read better if we kept indentation",
+					S2: "this is a long string\non multiple lines.\nit would read better if we kept indentation",
+				}),
+				slog.String("string1", "this is a long string\non multiple lines.\nit would read better if we kept indentation"),
+				slog.String("string11", "this is a long string\non multiple lines.\nit would read better if we kept indentation"),
+			),
+		),
+	)
+
+	strings := []string{
+		"abc\ndef",
+		"dsa\nqwe",
+		"abc\ndef",
+		"abc\ndef",
+	}
+
+	mapString := map[int]string{
+		1:    "abc\ndef",
+		1234: "abc\ndef",
+	}
+
+	slog.Info("longStrings",
+		slog.Any("slice", strings),
+		slog.Any("map", mapString),
+	)
+}
+
+func logSmall(log bool) {
+	if !log {
+		return
+	}
+
+	s1 := &A{
+		Num: 2,
+		Str: "haha",
+	}
+
+	slog.Info("in",
+		slog.Any("s1", s1),
+		slog.Any("s2", &B{}),
+	)
+
+	slog.Info("stats", "mem", ByteCount(9503159), "num", ByteString("hafananananana"))
+
+	a := 32
+	b := &a
+	slog.Info("bl", "b", &b)
+}
+
+type ByteCount int // Note this could be a struct as well.
+
+func (b ByteCount) String() string {
+	return fmt.Sprintf("from stringer: %[1]d %[1]d %[1]d", b)
+}
+
+type A struct {
+	Num int
+	Str string
+}
+
+func (a A) String() string {
+	return fmt.Sprintf("%d - %s", a.Num, a.Str)
+}
+
+type B struct {
+	pff int
+}
+
+type Person struct {
+	FirstName string
+	Age       int
+	Contact   Contact
+}
+
+type Contact struct {
+	Email   string
+	Address *Address
+}
+
+type Address struct {
+	Street string
+	Slice  *[]float64
+	Map    map[*string]**string
+}
+
+type ByteString string // Note this could be a struct as well.
+
+type testStruct struct {
+	A string
+	B int
+	C *int
+}
+
+type lazyTestStruct testStruct
+
+func (l lazyTestStruct) LogValue() slog.Value {
+	return slog.StringValue("dsadas")
+}
+
+type tt struct {
+	t time.Time
+}
+
+func printInfiniteLoop(log bool) {
+	if !log {
+		return
+	}
+
+	type Infinite struct {
+		I *Infinite
+	}
+
+	v1 := Infinite{}
+	v2 := Infinite{}
+	v3 := Infinite{}
+
+	v1.I = &v2
+	v2.I = &v3
+	v3.I = &v1
+
+	slog.Info("infinite", slog.Any("a", v3))
+}
+
+func printNoColor(log bool) {
+	if !log {
+		return
+	}
+
+	opts := &devslog.Options{
+		HandlerOptions: &slog.HandlerOptions{
+			AddSource: true,
+		},
+		NoColor: true,
+	}
+
+	l := slog.New(devslog.NewHandler(os.Stdout, opts))
+	l.Info("msg",
+		slog.String("string", "str"),
+		slog.Any("map", map[int]string{3: "three", 4: "four"}),
+	)
+}

--- a/_example/main.go
+++ b/_example/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/golang-cz/devslog"
@@ -91,6 +92,11 @@ func replaceAttr(groups []string, a slog.Attr) slog.Attr {
 		default:
 			a.Value = slog.StringValue("EMERGENCY")
 		}
+
+	case slog.SourceKey:
+		source := a.Value.Any().(*slog.Source)
+		source.File = filepath.Base(source.File)
+		return slog.Attr{}
 	}
 
 	return a

--- a/_example/main.go
+++ b/_example/main.go
@@ -96,7 +96,7 @@ func replaceAttr(groups []string, a slog.Attr) slog.Attr {
 	case slog.SourceKey:
 		source := a.Value.Any().(*slog.Source)
 		source.File = filepath.Base(source.File)
-		return slog.Attr{}
+		// return slog.Attr{}
 	}
 
 	return a

--- a/attributes.go
+++ b/attributes.go
@@ -17,19 +17,3 @@ func (a attributes) Less(i, j int) bool {
 
 	return a[i].Key < a[j].Key
 }
-
-func (a attributes) padding(c foregroundColor, colorFunction func(b []byte, fgColor foregroundColor) []byte) int {
-	var padding int
-	for _, e := range a {
-		color := len(e.Key)
-		if c != nil {
-			color = len(colorFunction([]byte(e.Key), c))
-		}
-
-		if color > padding {
-			padding = color
-		}
-	}
-
-	return padding
-}

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -11,7 +11,6 @@ func Test_Attributes(t *testing.T) {
 	testAttributesLess(t)
 	testAttributesLessGroupTrue(t)
 	testAttributesLessGroupFalse(t)
-	testAttributesPadding(t)
 }
 
 func testAttributesLen(t *testing.T) {
@@ -82,21 +81,5 @@ func testAttributesLessGroupFalse(t *testing.T) {
 
 	if less {
 		t.Error("Expected the first attribute to be less than the second")
-	}
-}
-
-func testAttributesPadding(t *testing.T) {
-	someValue := slog.StringValue("value")
-	attrs := attributes{
-		slog.Attr{Key: "key1", Value: someValue},
-		slog.Attr{Key: "key2", Value: someValue},
-	}
-
-	h := NewHandler(nil, nil)
-	padding := attrs.padding(fgMagenta, h.cs)
-
-	expectedPadding := 13
-	if padding != expectedPadding {
-		t.Errorf("Expected padding: %d, but got: %d", expectedPadding, padding)
 	}
 }

--- a/color.go
+++ b/color.go
@@ -73,7 +73,7 @@ func (h *developHandler) getColor(c Color) color {
 }
 
 // Color string foreground
-func (h *developHandler) cs(b []byte, fgColor foregroundColor) []byte {
+func (h *developHandler) colorString(b []byte, fgColor foregroundColor) []byte {
 	if h.opts.NoColor {
 		return b
 	}
@@ -84,7 +84,7 @@ func (h *developHandler) cs(b []byte, fgColor foregroundColor) []byte {
 }
 
 // Color string fainted
-func (h *developHandler) csf(b []byte, fgColor foregroundColor) []byte {
+func (h *developHandler) colorStringFainted(b []byte, fgColor foregroundColor) []byte {
 	if h.opts.NoColor {
 		return b
 	}
@@ -96,7 +96,7 @@ func (h *developHandler) csf(b []byte, fgColor foregroundColor) []byte {
 }
 
 // Color string background
-func (h *developHandler) csb(b []byte, fgColor foregroundColor, bgColor backgroundColor) []byte {
+func (h *developHandler) colorStringBackgorund(b []byte, fgColor foregroundColor, bgColor backgroundColor) []byte {
 	if h.opts.NoColor {
 		return b
 	}
@@ -108,12 +108,23 @@ func (h *developHandler) csb(b []byte, fgColor foregroundColor, bgColor backgrou
 }
 
 // Underline text
-func (h *developHandler) ul(b []byte) []byte {
+func (h *developHandler) underlineText(b []byte) []byte {
 	if h.opts.NoColor {
 		return b
 	}
 
 	b = append(underlineColor, b...)
+	b = append(b, resetColor...)
+	return b
+}
+
+// Fainted text
+func (h *developHandler) faintedText(b []byte) []byte {
+	if h.opts.NoColor {
+		return b
+	}
+
+	b = append(faintColor, b...)
 	b = append(b, resetColor...)
 	return b
 }

--- a/color_test.go
+++ b/color_test.go
@@ -10,10 +10,11 @@ func Test_Color(t *testing.T) {
 	testGetColor(t, h)
 
 	b := []byte("Hello")
-	testColorCs(t, b, h)
-	testColorCsf(t, b, h)
-	testColorCsb(t, b, h)
-	testColorUl(t, b, h)
+	testColorColorString(t, b, h)
+	testColorColorStringFainted(t, b, h)
+	testColorColorStringBackground(t, b, h)
+	testColorUnderlineText(t, b, h)
+	testColorFaintedText(t, b, h)
 }
 
 func testGetColor(t *testing.T, h *developHandler) {
@@ -32,8 +33,8 @@ func testGetColor(t *testing.T, h *developHandler) {
 	}
 }
 
-func testColorCs(t *testing.T, b []byte, h *developHandler) {
-	result := h.cs(b, fgGreen)
+func testColorColorString(t *testing.T, b []byte, h *developHandler) {
+	result := h.colorString(b, fgGreen)
 
 	expected := []byte("\x1b[32mHello\x1b[0m")
 	if !bytes.Equal(expected, result) {
@@ -41,8 +42,8 @@ func testColorCs(t *testing.T, b []byte, h *developHandler) {
 	}
 }
 
-func testColorCsf(t *testing.T, b []byte, h *developHandler) {
-	result := h.csf(b, fgBlue)
+func testColorColorStringFainted(t *testing.T, b []byte, h *developHandler) {
+	result := h.colorStringFainted(b, fgBlue)
 
 	expected := []byte("\x1b[2m\x1b[34mHello\x1b[0m")
 	if !bytes.Equal(expected, result) {
@@ -50,8 +51,8 @@ func testColorCsf(t *testing.T, b []byte, h *developHandler) {
 	}
 }
 
-func testColorCsb(t *testing.T, b []byte, h *developHandler) {
-	result := h.csb(b, fgYellow, bgRed)
+func testColorColorStringBackground(t *testing.T, b []byte, h *developHandler) {
+	result := h.colorStringBackgorund(b, fgYellow, bgRed)
 
 	expected := []byte("\x1b[41m\x1b[33mHello\x1b[0m")
 	if !bytes.Equal(expected, result) {
@@ -59,10 +60,19 @@ func testColorCsb(t *testing.T, b []byte, h *developHandler) {
 	}
 }
 
-func testColorUl(t *testing.T, b []byte, h *developHandler) {
-	result := h.ul(b)
+func testColorUnderlineText(t *testing.T, b []byte, h *developHandler) {
+	result := h.underlineText(b)
 
 	expected := []byte("\x1b[4mHello\x1b[0m")
+	if !bytes.Equal(expected, result) {
+		t.Errorf("\nExpected: %s\nResult:   %s\nExpected: %[1]q\nResult:   %[2]q", expected, result)
+	}
+}
+
+func testColorFaintedText(t *testing.T, b []byte, h *developHandler) {
+	result := h.faintedText(b)
+
+	expected := []byte("\x1b[2mHello\x1b[0m")
 	if !bytes.Equal(expected, result) {
 		t.Errorf("\nExpected: %s\nResult:   %s\nExpected: %[1]q\nResult:   %[2]q", expected, result)
 	}

--- a/devslog_test.go
+++ b/devslog_test.go
@@ -471,9 +471,7 @@ func testReplaceLevelAttributes(t *testing.T) {
 	logger.Debug("starting background job")
 	logger.Log(ctx, LevelTrace, "button clicked")
 
-	expected := fmt.Sprintf(
-		"\x1b[2m[]\x1b[0m \x1b[41m\x1b[30m EMERGENCY \x1b[0m \x1b[31mmissing pilots\x1b[0m\n  \x1b[35msev\x1b[0m: EMERGENCY\n\n\x1b[2m[]\x1b[0m \x1b[41m\x1b[30m ERROR \x1b[0m \x1b[31mfailed to start engines\x1b[0m\n  \x1b[35merr\x1b[0m: missing fuel\n  \x1b[35msev\x1b[0m: ERROR\n\n\x1b[2m[]\x1b[0m \x1b[43m\x1b[30m WARNING \x1b[0m \x1b[33mfalling back to default value\x1b[0m\n  \x1b[35msev\x1b[0m: WARNING\n\n\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m NOTICE \x1b[0m \x1b[32mall systems are running\x1b[0m\n  \x1b[35msev\x1b[0m: NOTICE\n\n\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32minitiating launch\x1b[0m\n  \x1b[35msev\x1b[0m: INFO\n\n\x1b[2m[]\x1b[0m \x1b[44m\x1b[30m DEBUG \x1b[0m \x1b[34mstarting background job\x1b[0m\n  \x1b[35msev\x1b[0m: DEBUG\n\n",
-	)
+	expected := "\x1b[2m[]\x1b[0m \x1b[41m\x1b[30m EMERGENCY \x1b[0m \x1b[31mmissing pilots\x1b[0m\n  \x1b[35msev\x1b[0m: EMERGENCY\n\n\x1b[2m[]\x1b[0m \x1b[41m\x1b[30m ERROR \x1b[0m \x1b[31mfailed to start engines\x1b[0m\n  \x1b[35merr\x1b[0m: missing fuel\n  \x1b[35msev\x1b[0m: ERROR\n\n\x1b[2m[]\x1b[0m \x1b[43m\x1b[30m WARNING \x1b[0m \x1b[33mfalling back to default value\x1b[0m\n  \x1b[35msev\x1b[0m: WARNING\n\n\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m NOTICE \x1b[0m \x1b[32mall systems are running\x1b[0m\n  \x1b[35msev\x1b[0m: NOTICE\n\n\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32minitiating launch\x1b[0m\n  \x1b[35msev\x1b[0m: INFO\n\n\x1b[2m[]\x1b[0m \x1b[44m\x1b[30m DEBUG \x1b[0m \x1b[34mstarting background job\x1b[0m\n  \x1b[35msev\x1b[0m: DEBUG\n\n"
 
 	if !bytes.Equal(w.WrittenData, []byte(expected)) {
 		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)

--- a/devslog_test.go
+++ b/devslog_test.go
@@ -303,18 +303,17 @@ func testSource(t *testing.T) {
 		HandlerOptions:    slogOpts,
 		MaxSlicePrintSize: 4,
 		SortKeys:          true,
-		TimeFormat:        "[15:04]",
+		TimeFormat:        "[]",
 		NewLineAfterLog:   true,
 	}
 
 	h := NewHandler(w, opts)
 	logger := slog.New(h)
 
-	timeString := h.csf([]byte(time.Now().Format("[15:04]")), fgWhite)
 	_, filename, l, _ := runtime.Caller(0)
 	logger.Info("message")
 
-	expected := fmt.Sprintf("%1s \x1b[34m@@@\x1b[0m \x1b[4m\x1b[33m%2s\x1b[0m\x1b[0m:\x1b[31m%v\x1b[0m\n\x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmessage\x1b[0m\n\n", timeString, filename, l+1)
+	expected := fmt.Sprintf("\x1b[2m[]\x1b[0m \x1b[2m\x1b[33m@@@\x1b[0m \x1b[4m\x1b[2m\x1b[36m%s\x1b[0m\x1b[0m\x1b[2m:\x1b[0m\x1b[2m\x1b[31m%d\x1b[0m\n\x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmessage\x1b[0m\n\n", filename, l+1)
 
 	if !bytes.Equal(w.WrittenData, []byte(expected)) {
 		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)
@@ -343,7 +342,7 @@ func testWithGroups(t *testing.T) {
 		slog.Any("a", "1"),
 	)
 
-	expected := "\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mMy INFO message\x1b[0m\n\x1b[32mG\x1b[0m \x1b[35mtest_group\x1b[0m: \n    \x1b[35ma\x1b[0m: 1\n\n"
+	expected := "\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mMy INFO message\x1b[0m\n\x1b[32mG\x1b[0m \x1b[35mtest_group\x1b[0m: \n    \x1b[35ma\x1b[0m: 1\n\n"
 
 	if !bytes.Equal(w.WrittenData, []byte(expected)) {
 		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)
@@ -370,7 +369,7 @@ func testWithGroupsEmpty(t *testing.T) {
 
 	logger.Info("My INFO message")
 
-	expected := "\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mMy INFO message\x1b[0m\n\n"
+	expected := "\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mMy INFO message\x1b[0m\n\n"
 
 	if !bytes.Equal(w.WrittenData, []byte(expected)) {
 		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)
@@ -398,7 +397,7 @@ func testWithAttributes(t *testing.T) {
 
 	logger.Info("My INFO message")
 
-	expected := "\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mMy INFO message\x1b[0m\n  \x1b[35ma\x1b[0m: 1\n\n"
+	expected := "\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mMy INFO message\x1b[0m\n  \x1b[35ma\x1b[0m: 1\n\n"
 
 	if !bytes.Equal(w.WrittenData, []byte(expected)) {
 		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)
@@ -456,14 +455,13 @@ func testReplaceLevelAttributes(t *testing.T) {
 		HandlerOptions:    slogOpts,
 		MaxSlicePrintSize: 4,
 		SortKeys:          true,
-		TimeFormat:        "[15:04]",
+		TimeFormat:        "[]",
 		NewLineAfterLog:   true,
 	}
 
 	h := NewHandler(w, opts)
 	logger := slog.New(h)
 
-	timeString := h.csf([]byte(time.Now().Format("[15:04]")), fgWhite)
 	ctx := context.Background()
 	logger.Log(ctx, LevelEmergency, "missing pilots")
 	logger.Error("failed to start engines", "err", "missing fuel")
@@ -474,8 +472,7 @@ func testReplaceLevelAttributes(t *testing.T) {
 	logger.Log(ctx, LevelTrace, "button clicked")
 
 	expected := fmt.Sprintf(
-		"%[1]s \x1b[41m\x1b[30m EMERGENCY \x1b[0m \x1b[31mmissing pilots\x1b[0m\n  \x1b[35msev\x1b[0m: EMERGENCY\n\n%[1]s \x1b[41m\x1b[30m ERROR \x1b[0m \x1b[31mfailed to start engines\x1b[0m\n  \x1b[35merr\x1b[0m: missing fuel\n  \x1b[35msev\x1b[0m: ERROR\n\n%[1]s \x1b[43m\x1b[30m WARNING \x1b[0m \x1b[33mfalling back to default value\x1b[0m\n  \x1b[35msev\x1b[0m: WARNING\n\n%[1]s \x1b[42m\x1b[30m NOTICE \x1b[0m \x1b[32mall systems are running\x1b[0m\n  \x1b[35msev\x1b[0m: NOTICE\n\n%[1]s \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32minitiating launch\x1b[0m\n  \x1b[35msev\x1b[0m: INFO\n\n%[1]s \x1b[44m\x1b[30m DEBUG \x1b[0m \x1b[34mstarting background job\x1b[0m\n  \x1b[35msev\x1b[0m: DEBUG\n\n",
-		timeString,
+		"\x1b[2m[]\x1b[0m \x1b[41m\x1b[30m EMERGENCY \x1b[0m \x1b[31mmissing pilots\x1b[0m\n  \x1b[35msev\x1b[0m: EMERGENCY\n\n\x1b[2m[]\x1b[0m \x1b[41m\x1b[30m ERROR \x1b[0m \x1b[31mfailed to start engines\x1b[0m\n  \x1b[35merr\x1b[0m: missing fuel\n  \x1b[35msev\x1b[0m: ERROR\n\n\x1b[2m[]\x1b[0m \x1b[43m\x1b[30m WARNING \x1b[0m \x1b[33mfalling back to default value\x1b[0m\n  \x1b[35msev\x1b[0m: WARNING\n\n\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m NOTICE \x1b[0m \x1b[32mall systems are running\x1b[0m\n  \x1b[35msev\x1b[0m: NOTICE\n\n\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32minitiating launch\x1b[0m\n  \x1b[35msev\x1b[0m: INFO\n\n\x1b[2m[]\x1b[0m \x1b[44m\x1b[30m DEBUG \x1b[0m \x1b[34mstarting background job\x1b[0m\n  \x1b[35msev\x1b[0m: DEBUG\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, []byte(expected)) {
@@ -530,7 +527,7 @@ func testString(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n  \x1b[35mempty\x1b[0m: \x1b[2m\x1b[37mempty\x1b[0m\n  \x1b[35ms\x1b[0m    : string\n  \x1b[35msp\x1b[0m   : string\n\x1b[34m*\x1b[0m \x1b[35murl\x1b[0m  : \x1b[4m\x1b[34mhttps://go.dev/\x1b[0m\x1b[0m\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n  \x1b[35mempty\x1b[0m: \x1b[2m\x1b[37mempty\x1b[0m\n  \x1b[35ms\x1b[0m    : string\n  \x1b[35msp\x1b[0m   : string\n\x1b[34m*\x1b[0m \x1b[35murl\x1b[0m  : \x1b[4m\x1b[34mhttps://go.dev/\x1b[0m\x1b[0m\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -554,7 +551,7 @@ func testIntFloat(t *testing.T, o *Options) {
 	)
 
 	expected := fmt.Sprintf(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[33m#\x1b[0m \x1b[35mf\x1b[0m : \x1b[33m1.21\x1b[0m\n\x1b[33m#\x1b[0m \x1b[35mfp\x1b[0m: \x1b[31m*\x1b[0m\x1b[33m1.21\x1b[0m\x1b[2m\x1b[37m \"%v\"\x1b[0m\n\x1b[33m#\x1b[0m \x1b[35mi\x1b[0m : \x1b[33m1\x1b[0m\n\x1b[33m#\x1b[0m \x1b[35mip\x1b[0m: \x1b[31m*\x1b[0m\x1b[33m1\x1b[0m\x1b[2m\x1b[37m \"%v\"\x1b[0m\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[33m#\x1b[0m \x1b[35mf\x1b[0m : \x1b[33m1.21\x1b[0m\n\x1b[33m#\x1b[0m \x1b[35mfp\x1b[0m: \x1b[31m*\x1b[0m\x1b[33m1.21\x1b[0m\x1b[2m\x1b[37m \"%v\"\x1b[0m\n\x1b[33m#\x1b[0m \x1b[35mi\x1b[0m : \x1b[33m1\x1b[0m\n\x1b[33m#\x1b[0m \x1b[35mip\x1b[0m: \x1b[31m*\x1b[0m\x1b[33m1\x1b[0m\x1b[2m\x1b[37m \"%v\"\x1b[0m\n\n",
 		fp,
 		ip,
 	)
@@ -575,7 +572,7 @@ func testBool(t *testing.T, o *Options) {
 		slog.Any("bp", bp),
 	)
 
-	expected := fmt.Sprintf("\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[31m#\x1b[0m \x1b[35mb\x1b[0m : \x1b[31mtrue\x1b[0m\n\x1b[31m#\x1b[0m \x1b[35mbp\x1b[0m: \x1b[31m*\x1b[0m\x1b[31mtrue\x1b[0m\x1b[2m\x1b[37m \"%v\"\x1b[0m\n\n", bp)
+	expected := fmt.Sprintf("\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[31m#\x1b[0m \x1b[35mb\x1b[0m : \x1b[31mtrue\x1b[0m\n\x1b[31m#\x1b[0m \x1b[35mbp\x1b[0m: \x1b[31m*\x1b[0m\x1b[31mtrue\x1b[0m\x1b[2m\x1b[37m \"%v\"\x1b[0m\n\n", bp)
 
 	if !bytes.Equal(w.WrittenData, []byte(expected)) {
 		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)
@@ -598,7 +595,7 @@ func testTime(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[36m@\x1b[0m \x1b[35md\x1b[0m : \x1b[36m99780h0m0s\x1b[0m\n\x1b[36m@\x1b[0m \x1b[35mt\x1b[0m : \x1b[36m2012-03-28 00:00:00 +0000 UTC\x1b[0m\n\x1b[36m@\x1b[0m \x1b[35mtp\x1b[0m: \x1b[36m2012-03-28 00:00:00 +0000 UTC\x1b[0m\n\x1b[36m@\x1b[0m \x1b[35mtp\x1b[0m: \x1b[36m99780h0m0s\x1b[0m\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[36m@\x1b[0m \x1b[35md\x1b[0m : \x1b[36m99780h0m0s\x1b[0m\n\x1b[36m@\x1b[0m \x1b[35mt\x1b[0m : \x1b[36m2012-03-28 00:00:00 +0000 UTC\x1b[0m\n\x1b[36m@\x1b[0m \x1b[35mtp\x1b[0m: \x1b[36m2012-03-28 00:00:00 +0000 UTC\x1b[0m\n\x1b[36m@\x1b[0m \x1b[35mtp\x1b[0m: \x1b[36m99780h0m0s\x1b[0m\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -619,7 +616,7 @@ func testError(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[31mE\x1b[0m \x1b[35me\x1b[0m: \n    \x1b[31m0\x1b[0m\x1b[37m: \x1b[0m\x1b[31merr 2\x1b[0m\n    \x1b[31m1\x1b[0m\x1b[37m: \x1b[0m\x1b[31merr 1\x1b[0m\n    \x1b[31m2\x1b[0m\x1b[37m: \x1b[0m\x1b[31mbroken\x1b[0m\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[31mE\x1b[0m \x1b[35me\x1b[0m: \n    \x1b[31m0\x1b[0m\x1b[37m: \x1b[0m\x1b[31merr 2\x1b[0m\n    \x1b[31m1\x1b[0m\x1b[37m: \x1b[0m\x1b[31merr 1\x1b[0m\n    \x1b[31m2\x1b[0m\x1b[37m: \x1b[0m\x1b[31mbroken\x1b[0m\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -638,7 +635,7 @@ func testSlice(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[32mS\x1b[0m \x1b[35ms\x1b[0m: \x1b[34m2\x1b[0m \x1b[32m[\x1b[0m\x1b[32m]\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\n    \x1b[32m0\x1b[0m: apple\n    \x1b[32m1\x1b[0m: ba na na\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[32mS\x1b[0m \x1b[35ms\x1b[0m: \x1b[34m2\x1b[0m \x1b[32m[\x1b[0m\x1b[32m]\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\n    \x1b[32m0\x1b[0m: apple\n    \x1b[32m1\x1b[0m: ba na na\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -660,7 +657,7 @@ func testSliceBig(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[32mS\x1b[0m \x1b[35ms\x1b[0m: \x1b[34m11\x1b[0m \x1b[32m[\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32m0\x1b[0m: \x1b[33m0\x1b[0m\n    \x1b[32m1\x1b[0m: \x1b[33m2\x1b[0m\n    \x1b[32m2\x1b[0m: \x1b[33m4\x1b[0m\n    \x1b[32m3\x1b[0m: \x1b[33m6\x1b[0m\n       \x1b[34m...\x1b[0m\x1b[32m]\x1b[0m\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[32mS\x1b[0m \x1b[35ms\x1b[0m: \x1b[34m11\x1b[0m \x1b[32m[\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32m0\x1b[0m: \x1b[33m0\x1b[0m\n    \x1b[32m1\x1b[0m: \x1b[33m2\x1b[0m\n    \x1b[32m2\x1b[0m: \x1b[33m4\x1b[0m\n    \x1b[32m3\x1b[0m: \x1b[33m6\x1b[0m\n       \x1b[34m...\x1b[0m\x1b[32m]\x1b[0m\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -682,7 +679,7 @@ func testMap(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[32mM\x1b[0m \x1b[35mm\x1b[0m  : \x1b[34m2\x1b[0m \x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\x1b[32mM\x1b[0m \x1b[35mmp\x1b[0m : \x1b[34m2\x1b[0m \x1b[31m*\x1b[0m\x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\x1b[32mM\x1b[0m \x1b[35mmpp\x1b[0m: \x1b[34m2\x1b[0m \x1b[31m*\x1b[0m\x1b[31m*\x1b[0m\x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[32mM\x1b[0m \x1b[35mm\x1b[0m  : \x1b[34m2\x1b[0m \x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\x1b[32mM\x1b[0m \x1b[35mmp\x1b[0m : \x1b[34m2\x1b[0m \x1b[31m*\x1b[0m\x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\x1b[32mM\x1b[0m \x1b[35mmpp\x1b[0m: \x1b[34m2\x1b[0m \x1b[31m*\x1b[0m\x1b[31m*\x1b[0m\x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -702,7 +699,7 @@ func testMapOfPointers(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[32mM\x1b[0m \x1b[35mm\x1b[0m: \x1b[34m2\x1b[0m \x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[31m*\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: a\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[32mM\x1b[0m \x1b[35mm\x1b[0m: \x1b[34m2\x1b[0m \x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[31m*\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: a\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -724,7 +721,7 @@ func testMapOfInterface(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[32mM\x1b[0m \x1b[35mm\x1b[0m  : \x1b[34m2\x1b[0m \x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mf\x1b[0m\x1b[33ma\x1b[0m\x1b[33mc\x1b[0m\x1b[33me\x1b[0m\x1b[33m \x1b[0m\x1b[33m{\x1b[0m\x1b[33m}\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\x1b[32mM\x1b[0m \x1b[35mmp\x1b[0m : \x1b[34m2\x1b[0m \x1b[31m*\x1b[0m\x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mf\x1b[0m\x1b[33ma\x1b[0m\x1b[33mc\x1b[0m\x1b[33me\x1b[0m\x1b[33m \x1b[0m\x1b[33m{\x1b[0m\x1b[33m}\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\x1b[32mM\x1b[0m \x1b[35mmpp\x1b[0m: \x1b[34m2\x1b[0m \x1b[31m*\x1b[0m\x1b[31m*\x1b[0m\x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mf\x1b[0m\x1b[33ma\x1b[0m\x1b[33mc\x1b[0m\x1b[33me\x1b[0m\x1b[33m \x1b[0m\x1b[33m{\x1b[0m\x1b[33m}\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[32mM\x1b[0m \x1b[35mm\x1b[0m  : \x1b[34m2\x1b[0m \x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mf\x1b[0m\x1b[33ma\x1b[0m\x1b[33mc\x1b[0m\x1b[33me\x1b[0m\x1b[33m \x1b[0m\x1b[33m{\x1b[0m\x1b[33m}\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\x1b[32mM\x1b[0m \x1b[35mmp\x1b[0m : \x1b[34m2\x1b[0m \x1b[31m*\x1b[0m\x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mf\x1b[0m\x1b[33ma\x1b[0m\x1b[33mc\x1b[0m\x1b[33me\x1b[0m\x1b[33m \x1b[0m\x1b[33m{\x1b[0m\x1b[33m}\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\x1b[32mM\x1b[0m \x1b[35mmpp\x1b[0m: \x1b[34m2\x1b[0m \x1b[31m*\x1b[0m\x1b[31m*\x1b[0m\x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mf\x1b[0m\x1b[33ma\x1b[0m\x1b[33mc\x1b[0m\x1b[33me\x1b[0m\x1b[33m \x1b[0m\x1b[33m{\x1b[0m\x1b[33m}\x1b[0m\n    \x1b[32m0\x1b[0m: a\n    \x1b[32m1\x1b[0m: b\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -761,7 +758,7 @@ func testStruct(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[33mS\x1b[0m \x1b[35ms\x1b[0m: \x1b[31m*\x1b[0m\x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mS\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mu\x1b[0m\x1b[33mc\x1b[0m\x1b[33mt\x1b[0m\x1b[33mT\x1b[0m\x1b[33me\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32mSlice\x1b[0m  : \x1b[34m0\x1b[0m \x1b[32m[\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32mMap\x1b[0m    : \x1b[34m0\x1b[0m \x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32mStruct\x1b[0m : \x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mu\x1b[0m\x1b[33mc\x1b[0m\x1b[33mt\x1b[0m\x1b[33m \x1b[0m\x1b[33m{\x1b[0m\x1b[33m \x1b[0m\x1b[33mB\x1b[0m\x1b[33m \x1b[0m\x1b[33mb\x1b[0m\x1b[33mo\x1b[0m\x1b[33mo\x1b[0m\x1b[33ml\x1b[0m\x1b[33m \x1b[0m\x1b[33m}\x1b[0m\n      \x1b[32mB\x1b[0m: \x1b[31mfalse\x1b[0m\n    \x1b[32mSliceP\x1b[0m : \x1b[34m0\x1b[0m \x1b[31m*\x1b[0m\x1b[32m[\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32mMapP\x1b[0m   : \x1b[34m0\x1b[0m \x1b[31m*\x1b[0m\x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32mStructP\x1b[0m: \x1b[31m*\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mu\x1b[0m\x1b[33mc\x1b[0m\x1b[33mt\x1b[0m\x1b[33m \x1b[0m\x1b[33m{\x1b[0m\x1b[33m \x1b[0m\x1b[33mB\x1b[0m\x1b[33m \x1b[0m\x1b[33mb\x1b[0m\x1b[33mo\x1b[0m\x1b[33mo\x1b[0m\x1b[33ml\x1b[0m\x1b[33m \x1b[0m\x1b[33m}\x1b[0m\n      \x1b[32mB\x1b[0m: \x1b[31mfalse\x1b[0m\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[33mS\x1b[0m \x1b[35ms\x1b[0m: \x1b[31m*\x1b[0m\x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mS\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mu\x1b[0m\x1b[33mc\x1b[0m\x1b[33mt\x1b[0m\x1b[33mT\x1b[0m\x1b[33me\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32mSlice\x1b[0m  : \x1b[34m0\x1b[0m \x1b[32m[\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32mMap\x1b[0m    : \x1b[34m0\x1b[0m \x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32mStruct\x1b[0m : \x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mu\x1b[0m\x1b[33mc\x1b[0m\x1b[33mt\x1b[0m\x1b[33m \x1b[0m\x1b[33m{\x1b[0m\x1b[33m \x1b[0m\x1b[33mB\x1b[0m\x1b[33m \x1b[0m\x1b[33mb\x1b[0m\x1b[33mo\x1b[0m\x1b[33mo\x1b[0m\x1b[33ml\x1b[0m\x1b[33m \x1b[0m\x1b[33m}\x1b[0m\n      \x1b[32mB\x1b[0m: \x1b[31mfalse\x1b[0m\n    \x1b[32mSliceP\x1b[0m : \x1b[34m0\x1b[0m \x1b[31m*\x1b[0m\x1b[32m[\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32mMapP\x1b[0m   : \x1b[34m0\x1b[0m \x1b[31m*\x1b[0m\x1b[33mm\x1b[0m\x1b[33ma\x1b[0m\x1b[33mp\x1b[0m\x1b[32m[\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[32m]\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\n    \x1b[32mStructP\x1b[0m: \x1b[31m*\x1b[0m\x1b[33ms\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mu\x1b[0m\x1b[33mc\x1b[0m\x1b[33mt\x1b[0m\x1b[33m \x1b[0m\x1b[33m{\x1b[0m\x1b[33m \x1b[0m\x1b[33mB\x1b[0m\x1b[33m \x1b[0m\x1b[33mb\x1b[0m\x1b[33mo\x1b[0m\x1b[33mo\x1b[0m\x1b[33ml\x1b[0m\x1b[33m \x1b[0m\x1b[33m}\x1b[0m\n      \x1b[32mB\x1b[0m: \x1b[31mfalse\x1b[0m\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -784,7 +781,7 @@ func testNilInterface(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[33mS\x1b[0m \x1b[35ms\x1b[0m: \x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mS\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mu\x1b[0m\x1b[33mc\x1b[0m\x1b[33mt\x1b[0m\x1b[33mW\x1b[0m\x1b[33mi\x1b[0m\x1b[33mt\x1b[0m\x1b[33mh\x1b[0m\x1b[33mI\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mf\x1b[0m\x1b[33ma\x1b[0m\x1b[33mc\x1b[0m\x1b[33me\x1b[0m\n    \x1b[32mData\x1b[0m: \x1b[31m<\x1b[0m\x1b[33mnil\x1b[0m\x1b[31m>\x1b[0m\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[33mS\x1b[0m \x1b[35ms\x1b[0m: \x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mS\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mu\x1b[0m\x1b[33mc\x1b[0m\x1b[33mt\x1b[0m\x1b[33mW\x1b[0m\x1b[33mi\x1b[0m\x1b[33mt\x1b[0m\x1b[33mh\x1b[0m\x1b[33mI\x1b[0m\x1b[33mn\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mf\x1b[0m\x1b[33ma\x1b[0m\x1b[33mc\x1b[0m\x1b[33me\x1b[0m\n    \x1b[32mData\x1b[0m: \x1b[31m<\x1b[0m\x1b[33mnil\x1b[0m\x1b[31m>\x1b[0m\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -803,7 +800,7 @@ func testGroup(t *testing.T, o *Options) {
 		),
 	)
 
-	expected := []byte("\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n  \x1b[35m1\x1b[0m: a\n\x1b[32mG\x1b[0m \x1b[35mg\x1b[0m: \n    \x1b[35m2\x1b[0m: b\n\n")
+	expected := []byte("\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n  \x1b[35m1\x1b[0m: a\n\x1b[32mG\x1b[0m \x1b[35mg\x1b[0m: \n    \x1b[35m2\x1b[0m: b\n\n")
 
 	if !bytes.Equal(w.WrittenData, expected) {
 		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)
@@ -833,7 +830,7 @@ func testLogValuer(t *testing.T, o *Options) {
 		slog.Any("item1", item1),
 	)
 
-	expected := []byte("\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mtest_log_valuer\x1b[0m\n\x1b[32mG\x1b[0m \x1b[35mitem1\x1b[0m: \n  \x1b[33m#\x1b[0m \x1b[35mA\x1b[0m: \x1b[33m5\x1b[0m\n    \x1b[35mB\x1b[0m: test\n\n")
+	expected := []byte("\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mtest_log_valuer\x1b[0m\n\x1b[32mG\x1b[0m \x1b[35mitem1\x1b[0m: \n  \x1b[33m#\x1b[0m \x1b[35mA\x1b[0m: \x1b[33m5\x1b[0m\n    \x1b[35mB\x1b[0m: test\n\n")
 
 	if !bytes.Equal(w.WrittenData, expected) {
 		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)
@@ -860,7 +857,7 @@ func testLogValuerPanic(t *testing.T, o *Options) {
 		slog.Any("item1", item1),
 	)
 
-	expectedPrefix := []byte("\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mtest_log_valuer_panic\x1b[0m\n\x1b[31mE\x1b[0m \x1b[35mitem1\x1b[0m: \n    \x1b[31m0\x1b[0m\x1b[37m: \x1b[0m\x1b[31mLogValue panicked\n")
+	expectedPrefix := []byte("\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mtest_log_valuer_panic\x1b[0m\n\x1b[31mE\x1b[0m \x1b[35mitem1\x1b[0m: \n    \x1b[31m0\x1b[0m\x1b[37m: \x1b[0m\x1b[31mLogValue panicked\n")
 	if !bytes.HasPrefix(w.WrittenData, expectedPrefix) {
 		t.Errorf("\nGot:\n%s\n , %[1]q expected it to contain panic stack trace", w.WrittenData)
 	}
@@ -884,7 +881,7 @@ func testStringer(t *testing.T, o *Options) {
 		slog.Any("item1", item1),
 	)
 
-	expected := []byte("\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mtest_stringer\x1b[0m\n  \x1b[35mitem1\x1b[0m: A: test\n\n")
+	expected := []byte("\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mtest_stringer\x1b[0m\n  \x1b[35mitem1\x1b[0m: A: test\n\n")
 
 	if !bytes.Equal(w.WrittenData, expected) {
 		t.Errorf("\nExpected:\n%s\nGot:\n%s\nExpected:\n%[1]q\nGot:\n%[2]q", expected, w.WrittenData)
@@ -910,7 +907,7 @@ func testStringerInner(t *testing.T, o *Options) {
 	)
 
 	expected := []byte(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mtest_stringer_inner\x1b[0m\n\x1b[33mS\x1b[0m \x1b[35mitem1\x1b[0m: \x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33mS\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mE\x1b[0m\x1b[33mx\x1b[0m\x1b[33ma\x1b[0m\x1b[33mm\x1b[0m\x1b[33mp\x1b[0m\x1b[33ml\x1b[0m\x1b[33me\x1b[0m\x1b[33m2\x1b[0m\n    \x1b[32mInner\x1b[0m: A: test\n    \x1b[32mOther\x1b[0m: \x1b[33m42\x1b[0m\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mtest_stringer_inner\x1b[0m\n\x1b[33mS\x1b[0m \x1b[35mitem1\x1b[0m: \x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33mS\x1b[0m\x1b[33mt\x1b[0m\x1b[33mr\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mg\x1b[0m\x1b[33me\x1b[0m\x1b[33mr\x1b[0m\x1b[33mE\x1b[0m\x1b[33mx\x1b[0m\x1b[33ma\x1b[0m\x1b[33mm\x1b[0m\x1b[33mp\x1b[0m\x1b[33ml\x1b[0m\x1b[33me\x1b[0m\x1b[33m2\x1b[0m\n    \x1b[32mInner\x1b[0m: A: test\n    \x1b[32mOther\x1b[0m: \x1b[33m42\x1b[0m\n\n",
 	)
 
 	if !bytes.Equal(w.WrittenData, expected) {
@@ -959,7 +956,7 @@ func testInfinite(t *testing.T, o *Options) {
 	)
 
 	expected := fmt.Sprintf(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[33mS\x1b[0m \x1b[35mi\x1b[0m: \x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mI\x1b[0m\x1b[33mn\x1b[0m\x1b[33mf\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mi\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\n    \x1b[32mI\x1b[0m: \x1b[31m*\x1b[0m\x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mI\x1b[0m\x1b[33mn\x1b[0m\x1b[33mf\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mi\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\n      \x1b[32mI\x1b[0m: \x1b[31m*\x1b[0m\x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mI\x1b[0m\x1b[33mn\x1b[0m\x1b[33mf\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mi\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\n        \x1b[32mI\x1b[0m: \x1b[31m*\x1b[0m\x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mI\x1b[0m\x1b[33mn\x1b[0m\x1b[33mf\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mi\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\n          \x1b[32mI\x1b[0m: &{%p}\n\n",
+		"\x1b[2m[]\x1b[0m \x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[33mS\x1b[0m \x1b[35mi\x1b[0m: \x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mI\x1b[0m\x1b[33mn\x1b[0m\x1b[33mf\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mi\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\n    \x1b[32mI\x1b[0m: \x1b[31m*\x1b[0m\x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mI\x1b[0m\x1b[33mn\x1b[0m\x1b[33mf\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mi\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\n      \x1b[32mI\x1b[0m: \x1b[31m*\x1b[0m\x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mI\x1b[0m\x1b[33mn\x1b[0m\x1b[33mf\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mi\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\n        \x1b[32mI\x1b[0m: \x1b[31m*\x1b[0m\x1b[33md\x1b[0m\x1b[33me\x1b[0m\x1b[33mv\x1b[0m\x1b[33ms\x1b[0m\x1b[33ml\x1b[0m\x1b[33mo\x1b[0m\x1b[33mg\x1b[0m\x1b[33m.\x1b[0m\x1b[33mI\x1b[0m\x1b[33mn\x1b[0m\x1b[33mf\x1b[0m\x1b[33mi\x1b[0m\x1b[33mn\x1b[0m\x1b[33mi\x1b[0m\x1b[33mt\x1b[0m\x1b[33me\x1b[0m\n          \x1b[32mI\x1b[0m: &{%p}\n\n",
 		v2.I,
 	)
 
@@ -992,7 +989,7 @@ func testSameSourceInfoColor(t *testing.T) {
 	line++
 
 	expected := fmt.Sprintf(
-		"\x1b[2m\x1b[37m[]\x1b[0m \x1b[34m@@@\x1b[0m \x1b[4m\x1b[33m%s:%d\x1b[0m\x1b[0m\n\x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[33m#\x1b[0m \x1b[35mi\x1b[0m: \x1b[33m1\x1b[0m\n", file, line,
+		"\x1b[2m[]\x1b[0m \x1b[2m\x1b[33m@@@\x1b[0m \x1b[4m\x1b[34m%s:%d\x1b[0m\x1b[0m\n\x1b[42m\x1b[30m INFO \x1b[0m \x1b[32mmsg\x1b[0m\n\x1b[33m#\x1b[0m \x1b[35mi\x1b[0m: \x1b[33m1\x1b[0m\n", file, line,
 	)
 
 	if !bytes.Equal(w.WrittenData, []byte(expected)) {


### PR DESCRIPTION
### Description
Updated color generating.
Change source color.
Generating source info same as builtin handlers, and processing replace attrs for source.
Fix https://github.com/golang-cz/devslog/issues/49
Added `_example`

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
