### PR TITLE
feat: respect NO_COLOR and TERM=dumb env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,12 @@ slog.SetDefault(logger)
 | StringerFormatter   | Use Stringer interface for formatting                          | false          | bool                 |
 | NoColor             | Disable coloring                                               | false          | bool                 |
 | SameSourceInfoColor | Keep same color for whole source info                          | false          | bool                 |
+
+### Environment variables
+
+Coloring is also disabled automatically when:
+
+- `NO_COLOR` is set to any non-empty value (see [no-color.org](https://no-color.org/)).
+- `TERM=dumb`.
+
+The environment signal wins over an explicit `NoColor: false` in `Options`.

--- a/devslog.go
+++ b/devslog.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/url"
+	"os"
 	"reflect"
 	"runtime"
 	"sort"
@@ -118,7 +119,25 @@ func NewHandler(out io.Writer, o *Options) *developHandler {
 		}
 	}
 
+	if envDisablesColor() {
+		h.opts.NoColor = true
+	}
+
 	return h
+}
+
+// envDisablesColor reports whether the environment signals that ANSI color
+// output should be suppressed. Follows the NO_COLOR convention
+// (https://no-color.org/) — any non-empty value disables color — and the
+// older TERM=dumb convention.
+func envDisablesColor() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return true
+	}
+	if os.Getenv("TERM") == "dumb" {
+		return true
+	}
+	return false
 }
 
 func ensureValidColor(c Color, defaultColor Color) Color {

--- a/devslog_test.go
+++ b/devslog_test.go
@@ -16,6 +16,7 @@ func TestNewHandler(t *testing.T) {
 	testNewHandlerWithOptions(t)
 	testNewHandlerWithNilOptions(t)
 	testNewHandlerWithNilSlogHandlerOptions(t)
+	testNewHandlerEnvDisablesColor(t)
 }
 
 func TestMethods(t *testing.T) {
@@ -158,6 +159,43 @@ func testNewHandlerWithNilSlogHandlerOptions(t *testing.T) {
 	if h.out != nil {
 		t.Errorf("Expected writer to be nil")
 	}
+}
+
+func testNewHandlerEnvDisablesColor(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"no env", nil, false},
+		{"NO_COLOR=1", map[string]string{"NO_COLOR": "1"}, true},
+		{"NO_COLOR=anything", map[string]string{"NO_COLOR": "yes please"}, true},
+		{"NO_COLOR empty is ignored", map[string]string{"NO_COLOR": ""}, false},
+		{"TERM=dumb", map[string]string{"TERM": "dumb"}, true},
+		{"TERM=xterm-256color", map[string]string{"TERM": "xterm-256color"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			h := NewHandler(nil, nil)
+			if h.opts.NoColor != tc.want {
+				t.Errorf("NoColor = %v, want %v", h.opts.NoColor, tc.want)
+			}
+		})
+	}
+
+	t.Run("env overrides explicit NoColor=false", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "1")
+
+		h := NewHandler(nil, &Options{NoColor: false})
+		if !h.opts.NoColor {
+			t.Error("NO_COLOR env must override explicit NoColor=false")
+		}
+	})
 }
 
 func testEnabled(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,15 @@
+package devslog
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain neutralizes color-related environment variables so the suite's
+// ANSI-escape assertions are hermetic regardless of the developer's shell.
+// Per-test cases that exercise env-driven color disabling use t.Setenv.
+func TestMain(m *testing.M) {
+	os.Unsetenv("NO_COLOR")
+	os.Unsetenv("TERM")
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Adds the standard env-var wiring so devslog plays nice with CLI tools that need to honor `NO_COLOR` (https://no-color.org/) and the older `TERM=dumb` convention. The lib already had `Options.NoColor` — this just lets the environment flip it.

The env signal wins over an explicit `NoColor: false`. That matches the spec's intent ("the user gets the final say on color") and there's no `ForceColor` opt today, so there's nothing to override yet. If you'd prefer the opposite semantics, happy to flip it.

---

## Test plan

- `go test -race ./...` — passes locally.
- Added `TestMain` that unsets `NO_COLOR` / `TERM` so the existing 28 color-asserting tests stay hermetic regardless of developer shell. Without it, anyone running tests with `NO_COLOR=1` in their shell after this change would have the whole suite go red. Confirmed `NO_COLOR=1 go test ./...` still passes.
- New `testNewHandlerEnvDisablesColor` covers: no env, `NO_COLOR=1`, arbitrary `NO_COLOR` value, empty `NO_COLOR` (treated as unset), `TERM=dumb`, `TERM=xterm-256color`, and the override case.

## Notes

- No new public API surface — `Options.NoColor` is still the single gate; the env just flips it inside `NewHandler`.
- README gets a small "Environment variables" subsection under `Options`.
